### PR TITLE
Add unit tests for the "happy" paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module td-grpc-bootstrap
 
 go 1.13
 
-require github.com/google/uuid v1.1.1
+require (
+	github.com/google/go-cmp v0.4.0
+	github.com/google/uuid v1.1.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main_test.go
+++ b/main_test.go
@@ -16,12 +16,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 )
 
@@ -62,7 +64,15 @@ func TestGenerate(t *testing.T) {
 		t.Fatalf("want no error, got: %v", err)
 	}
 	if want != string(got) {
-		t.Fatalf("\nwant:\n%v\n----------------\ngot:\n%v",
+		var wantParsed, gotParsed interface{}
+		err1 := json.Unmarshal([]byte(want), &wantParsed)
+		err2 := json.Unmarshal(got, &gotParsed)
+		if err1 != nil || err2 != nil {
+			t.Logf("problem parsing json, error for want: %v, got: %v", err1, err2)
+		} else if diff := cmp.Diff(wantParsed, gotParsed); diff != "" {
+			t.Fatalf("not equal (-want +got):\n%s", diff)
+		}
+		t.Fatalf("not equal, but structure matched\nwant:\n%v\n----------------\ngot:\n%v",
 			want, string(got))
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,120 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestGenerate(t *testing.T) {
+	uuid.SetRand(rand.New(rand.NewSource(1)))
+	in := configInput{
+		xdsServerUri:     "example.com:443",
+		gcpProjectNumber: 123456789012345,
+		vpcNetworkName:   "thedefault",
+		ip:               "10.9.8.7",
+		zone:             "uscentral-5",
+	}
+	expected := `{
+  "xds_servers": [
+    {
+      "server_uri": "example.com:443",
+      "channel_creds": [
+        {
+          "type": "google_default"
+        }
+      ]
+    }
+  ],
+  "node": {
+    "id": "52fdfc07-2182-454f-963f-5f0f9a621d72~10.9.8.7",
+    "cluster": "cluster",
+    "metadata": {
+      "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
+      "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
+    },
+    "locality": {
+      "zone": "uscentral-5"
+    }
+  }
+}`
+	out, err := generate(in)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if expected != string(out) {
+		t.Fatalf("\nexpected:\n%v\n----------------\ngot:\n%v",
+			expected, string(out))
+	}
+}
+
+func TestGetZone(t *testing.T) {
+	server := httptest.NewServer(nil)
+	defer server.Close()
+	overrideHttp(server)
+	expected := "us-central5-c"
+	http.HandleFunc("metadata.google.internal/computeMetadata/v1/instance/zone",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Metadata-Flavor") != "Google" {
+				http.Error(w, "Missing Metadata-Flavor", 403)
+				return
+			}
+			w.Write([]byte("projects/123456789012345/zones/us-central5-c"))
+		})
+	actual, err := getZone()
+	if err != nil {
+		t.Fatalf("expected no error, got :%v", err)
+	}
+	if expected != actual {
+		t.Fatalf("expected %v, got: %v", expected, actual)
+	}
+}
+
+func TestGetProjectId(t *testing.T) {
+	server := httptest.NewServer(nil)
+	defer server.Close()
+	overrideHttp(server)
+	expected := int64(123456789012345)
+	http.HandleFunc("metadata.google.internal/computeMetadata/v1/project/numeric-project-id",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Metadata-Flavor") != "Google" {
+				http.Error(w, "Missing Metadata-Flavor", 403)
+				return
+			}
+			w.Write([]byte("123456789012345"))
+		})
+	actual, err := getProjectId()
+	if err != nil {
+		t.Fatalf("expected no error, got :%v", err)
+	}
+	if expected != actual {
+		t.Fatalf("expected %v, got: %v", expected, actual)
+	}
+}
+
+func overrideHttp(s *httptest.Server) {
+	http.DefaultTransport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "tcp", s.Listener.Addr().String())
+		},
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -34,7 +34,7 @@ func TestGenerate(t *testing.T) {
 		ip:               "10.9.8.7",
 		zone:             "uscentral-5",
 	}
-	expected := `{
+	want := `{
   "xds_servers": [
     {
       "server_uri": "example.com:443",
@@ -57,21 +57,21 @@ func TestGenerate(t *testing.T) {
     }
   }
 }`
-	out, err := generate(in)
+	got, err := generate(in)
 	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
+		t.Fatalf("want no error, got: %v", err)
 	}
-	if expected != string(out) {
-		t.Fatalf("\nexpected:\n%v\n----------------\ngot:\n%v",
-			expected, string(out))
+	if want != string(got) {
+		t.Fatalf("\nwant:\n%v\n----------------\ngot:\n%v",
+			want, string(got))
 	}
 }
 
 func TestGetZone(t *testing.T) {
 	server := httptest.NewServer(nil)
 	defer server.Close()
-	overrideHttp(server)
-	expected := "us-central5-c"
+	overrideHTTP(server)
+	want := "us-central5-c"
 	http.HandleFunc("metadata.google.internal/computeMetadata/v1/instance/zone",
 		func(w http.ResponseWriter, r *http.Request) {
 			if r.Header.Get("Metadata-Flavor") != "Google" {
@@ -80,20 +80,20 @@ func TestGetZone(t *testing.T) {
 			}
 			w.Write([]byte("projects/123456789012345/zones/us-central5-c"))
 		})
-	actual, err := getZone()
+	got, err := getZone()
 	if err != nil {
-		t.Fatalf("expected no error, got :%v", err)
+		t.Fatalf("want no error, got :%v", err)
 	}
-	if expected != actual {
-		t.Fatalf("expected %v, got: %v", expected, actual)
+	if want != got {
+		t.Fatalf("want %v, got: %v", want, got)
 	}
 }
 
 func TestGetProjectId(t *testing.T) {
 	server := httptest.NewServer(nil)
 	defer server.Close()
-	overrideHttp(server)
-	expected := int64(123456789012345)
+	overrideHTTP(server)
+	want := int64(123456789012345)
 	http.HandleFunc("metadata.google.internal/computeMetadata/v1/project/numeric-project-id",
 		func(w http.ResponseWriter, r *http.Request) {
 			if r.Header.Get("Metadata-Flavor") != "Google" {
@@ -102,16 +102,16 @@ func TestGetProjectId(t *testing.T) {
 			}
 			w.Write([]byte("123456789012345"))
 		})
-	actual, err := getProjectId()
+	got, err := getProjectId()
 	if err != nil {
-		t.Fatalf("expected no error, got :%v", err)
+		t.Fatalf("want no error, got :%v", err)
 	}
-	if expected != actual {
-		t.Fatalf("expected %v, got: %v", expected, actual)
+	if want != got {
+		t.Fatalf("want %v, got: %v", want, got)
 	}
 }
 
-func overrideHttp(s *httptest.Server) {
+func overrideHTTP(s *httptest.Server) {
 	http.DefaultTransport = &http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, "tcp", s.Listener.Addr().String())


### PR DESCRIPTION
Gets us to "28.9% of statements", which is pathetic, but sort of
expected for a command line tool like this. main() and getHostIp() are
entirely uncovered.

-------------------

While everything else in the repo is trivial, I wouldn't be surprised if something in these tests strikes you as wrong/needing improvement. That said, they're still close to trivial.