### PR TITLE
Add Cloud Build build-on-merge

### DIFF
--- a/tools/cloudbuild-artifacts.yaml
+++ b/tools/cloudbuild-artifacts.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: golang:1.14-alpine
+  args: ['go', 'build', './...']
+- name: golang:1.14-alpine
+  args: ['go', 'test', './...']
+- name: alpine
+  args: ['./tools/package.sh', '$COMMIT_SHA']
+options:
+  env:
+  - CGO_ENABLED=0
+artifacts:
+  objects:
+    location: 'gs://grpc-td-builds/td-grpc-bootstrap/'
+    paths: ['td-grpc-bootstrap-${COMMIT_SHA}.tar.gz']

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 VERSION"
+  echo ""
+  echo "Expected to be run from the root of the repo"
+  exit 1
+fi
+
+version="$1"
+mkdir td-grpc-bootstrap-${version}/
+cp td-grpc-bootstrap td-grpc-bootstrap-${version}/
+tar czf td-grpc-bootstrap-${version}.tar.gz td-grpc-bootstrap-${version}/
+rm -r td-grpc-bootstrap-${version}/

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -23,7 +23,7 @@ if [[ $# -ne 1 ]]; then
 fi
 
 version="$1"
-mkdir td-grpc-bootstrap-${version}/
-cp td-grpc-bootstrap td-grpc-bootstrap-${version}/
-tar czf td-grpc-bootstrap-${version}.tar.gz td-grpc-bootstrap-${version}/
-rm -r td-grpc-bootstrap-${version}/
+mkdir "td-grpc-bootstrap-${version}/"
+cp td-grpc-bootstrap "td-grpc-bootstrap-${version}/"
+tar czf "td-grpc-bootstrap-${version}.tar.gz" "td-grpc-bootstrap-${version}/"
+rm -r "td-grpc-bootstrap-${version}/"


### PR DESCRIPTION
This generates artifacts to a GCS bucket that can be used for testing.
It is not intended to be used on PRs until they are merged.

------

This is intended to simplify the testing process at step 2 of go/grpc/td-grpc-bootstrap-release

I couldn't bring myself to setup Kokoro. Cloud Build actually turned out much easier to work with. The basic premise of Cloud Build is you have the source code available and then you run commands on it, but you can only run commands via containers. The containers have access to the source, so any modifications/additions to the source directory will be kept after the container returns.

Tested with: `gcloud builds submit --config tools/cloudbuild-artifacts.yaml --substitutions=COMMIT_SHA=IMAGINETHISISASHA`. The COMMIT_SHA is only automatically set via a push trigger, so I had to fake it for testing. Build results: https://console.cloud.google.com/cloud-build/builds/e58a1262-58c0-477c-b70a-9bad63461cb2?project=830293263384 . Note that the logs are private. It is probably possible to make the logs public, but meh; it won't really look any different than Travis.