### PR TITLE
Emit file_watcher plugin configuration with default values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module td-grpc-bootstrap
 go 1.13
 
 require (
-	github.com/google/go-cmp v0.4.0
+	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
-github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -2,4 +2,5 @@ github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: failed to determine project id: %s\n", err)
 			os.Exit(1)
+
 		}
 	}
 	ip, err := getHostIp()

--- a/main.go
+++ b/main.go
@@ -35,14 +35,9 @@ var (
 	outputName       = flag.String("output", "-", "output file name")
 	gcpProjectNumber = flag.Int64("gcp-project-number", 0,
 		"the gcp project number. If unknown, can be found via 'gcloud projects list'")
-	vpcNetworkName = flag.String("vpc-network-name", "default", "VPC network name")
-
-	// Notice: This flag is EXPERIMENTAL and may be changed or removed in a later release.
-	enableFileWatcherConfig = flag.Bool("enable-file-watcher-config", false, "whether or not to generate file_watcher certificate provider config")
+	vpcNetworkName          = flag.String("vpc-network-name", "default", "VPC network name")
+	enableFileWatcherConfig = flag.Bool("enable-file-watcher-config", false, "whether or not to generate file_watcher certificate provider config. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 )
-
-// For overriding in unit tests.
-var newUUIDString = func() string { return uuid.New().String() }
 
 func main() {
 	flag.Parse()
@@ -52,7 +47,6 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: failed to determine project id: %s\n", err)
 			os.Exit(1)
-
 		}
 	}
 	ip, err := getHostIp()
@@ -124,7 +118,7 @@ func generate(in configInput) ([]byte, error) {
 			},
 		},
 		Node: &node{
-			Id:      newUUIDString() + "~" + in.ip,
+			Id:      uuid.New().String() + "~" + in.ip,
 			Cluster: "cluster", // unused by TD
 			Locality: &locality{
 				Zone: in.zone,

--- a/main.go
+++ b/main.go
@@ -35,7 +35,9 @@ var (
 	outputName       = flag.String("output", "-", "output file name")
 	gcpProjectNumber = flag.Int64("gcp-project-number", 0,
 		"the gcp project number. If unknown, can be found via 'gcloud projects list'")
-	vpcNetworkName          = flag.String("vpc-network-name", "default", "VPC network name")
+	vpcNetworkName = flag.String("vpc-network-name", "default", "VPC network name")
+
+	// Notice: This flag is EXPERIMENTAL and may be changed or removed in a later release.
 	enableFileWatcherConfig = flag.Bool("enable-file-watcher-config", false, "whether or not to generate file_watcher certificate provider config")
 )
 

--- a/main.go
+++ b/main.go
@@ -36,17 +36,6 @@ var gcpProjectNumber = flag.Int64("gcp-project-number", 0,
 	"the gcp project number. If unknown, can be found via 'gcloud projects list'")
 var vpcNetworkName = flag.String("vpc-network-name", "default", "VPC network name")
 
-const (
-	privateSPIFFECertProviderInstanceName = "google_cloud_private_spiffe"
-	privateSPIFFECertProviderName         = "file_watcher"
-	privateSPIFFECertificateFile          = "/var/run/gke-spiffe/certs/certificates.pem"
-	privateSPIFFEKeyFile                  = "/var/run/gke-spiffe/certs/private_key.pem"
-	privateSPIFFECAFile                   = "/var/run/gke-spiffe/certs/ca_certificates.pem"
-	// The file_watcher plugin will parse this a Duration proto, but it is totally
-	// fine to just emit a string here.
-	privateSPIFFERefreshInterval = "10m"
-)
-
 // For overriding in unit tests.
 var newUUIDString = func() string { return uuid.New().String() }
 
@@ -138,13 +127,15 @@ func generate(in configInput) ([]byte, error) {
 			},
 		},
 		CertificateProviders: map[string]certificateProviderConfig{
-			privateSPIFFECertProviderInstanceName: {
-				PluginName: privateSPIFFECertProviderName,
+			"google_cloud_private_spiffe": {
+				PluginName: "file_watcher",
 				Config: privateSPIFFEConfig{
-					CertificateFile:   privateSPIFFECertificateFile,
-					PrivateKeyFile:    privateSPIFFEKeyFile,
-					CACertificateFile: privateSPIFFECAFile,
-					RefreshInterval:   privateSPIFFERefreshInterval,
+					CertificateFile:   "/var/run/gke-spiffe/certs/certificates.pem",
+					PrivateKeyFile:    "/var/run/gke-spiffe/certs/private_key.pem",
+					CACertificateFile: "/var/run/gke-spiffe/certs/ca_certificates.pem",
+					// The file_watcher plugin will parse this a Duration proto, but it is totally
+					// fine to just emit a string here.
+					RefreshInterval: "10m",
 				},
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func generate(in configInput) ([]byte, error) {
 					CACertificateFile: "/var/run/gke-spiffe/certs/ca_certificates.pem",
 					// The file_watcher plugin will parse this a Duration proto, but it is totally
 					// fine to just emit a string here.
-					RefreshInterval: "10m",
+					RefreshInterval: "600s",
 				},
 			},
 		}

--- a/main.go
+++ b/main.go
@@ -35,8 +35,8 @@ var (
 	outputName       = flag.String("output", "-", "output file name")
 	gcpProjectNumber = flag.Int64("gcp-project-number", 0,
 		"the gcp project number. If unknown, can be found via 'gcloud projects list'")
-	vpcNetworkName          = flag.String("vpc-network-name", "default", "VPC network name")
-	enableFileWatcherConfig = flag.Bool("enable-file-watcher-config", false, "whether or not to generate file_watcher certificate provider config. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	vpcNetworkName     = flag.String("vpc-network-name", "default", "VPC network name")
+	includePSMSecurity = flag.Bool("include-psm-security", false, "whether or not to generate config required for PSM security. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 )
 
 func main() {
@@ -60,12 +60,12 @@ func main() {
 		zone = ""
 	}
 	config, err := generate(configInput{
-		xdsServerUri:            *xdsServerUri,
-		gcpProjectNumber:        *gcpProjectNumber,
-		vpcNetworkName:          *vpcNetworkName,
-		ip:                      ip,
-		zone:                    zone,
-		enableFileWatcherConfig: *enableFileWatcherConfig,
+		xdsServerUri:       *xdsServerUri,
+		gcpProjectNumber:   *gcpProjectNumber,
+		vpcNetworkName:     *vpcNetworkName,
+		ip:                 ip,
+		zone:               zone,
+		includePSMSecurity: *includePSMSecurity,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to generate config: %s\n", err)
@@ -99,12 +99,12 @@ func main() {
 }
 
 type configInput struct {
-	xdsServerUri            string
-	gcpProjectNumber        int64
-	vpcNetworkName          string
-	ip                      string
-	zone                    string
-	enableFileWatcherConfig bool
+	xdsServerUri       string
+	gcpProjectNumber   int64
+	vpcNetworkName     string
+	ip                 string
+	zone               string
+	includePSMSecurity bool
 }
 
 func generate(in configInput) ([]byte, error) {
@@ -129,7 +129,7 @@ func generate(in configInput) ([]byte, error) {
 			},
 		},
 	}
-	if in.enableFileWatcherConfig {
+	if in.includePSMSecurity {
 		c.CertificateProviders = map[string]certificateProviderConfig{
 			"google_cloud_private_spiffe": {
 				PluginName: "file_watcher",

--- a/main_test.go
+++ b/main_test.go
@@ -68,12 +68,12 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "happy case file watcher config",
 			input: configInput{
-				xdsServerUri:            "example.com:443",
-				gcpProjectNumber:        123456789012345,
-				vpcNetworkName:          "thedefault",
-				ip:                      "10.9.8.7",
-				zone:                    "uscentral-5",
-				enableFileWatcherConfig: true,
+				xdsServerUri:       "example.com:443",
+				gcpProjectNumber:   123456789012345,
+				vpcNetworkName:     "thedefault",
+				ip:                 "10.9.8.7",
+				zone:               "uscentral-5",
+				includePSMSecurity: true,
 			},
 			wantOutput: `{
   "xds_servers": [

--- a/main_test.go
+++ b/main_test.go
@@ -105,7 +105,7 @@ func TestGenerate2(t *testing.T) {
 							CertificateFile:   "/var/run/gke-spiffe/certs/certificates.pem",
 							PrivateKeyFile:    "/var/run/gke-spiffe/certs/private_key.pem",
 							CACertificateFile: "/var/run/gke-spiffe/certs/ca_certificates.pem",
-							RefreshInterval:   "10m",
+							RefreshInterval:   "600s",
 						},
 					},
 				},

--- a/main_test.go
+++ b/main_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerate2(t *testing.T) {
+func TestGenerate(t *testing.T) {
 	origUUIString := newUUIDString
 	newUUIDString = func() string { return "dummy-uuid" }
 	defer func() { newUUIDString = origUUIString }()
@@ -130,6 +130,7 @@ func TestGenerate2(t *testing.T) {
 		})
 	}
 }
+
 func TestGetZone(t *testing.T) {
 	server := httptest.NewServer(nil)
 	defer server.Close()


### PR DESCRIPTION
This change makes the bootstrap generator emit the file_watcher plugin configuration by default. Currently there are no flags added to control this behavior. I can add them if we think it is necessary.