### PR TITLE
Add support for "grpc_server_resource_name_id" field

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,6 +128,7 @@ func generate(in configInput) ([]byte, error) {
 				"TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": strconv.FormatInt(in.gcpProjectNumber, 10),
 			},
 		},
+		GRPCServerResourceNameId: "grpc/server",
 	}
 	if in.includePSMSecurity {
 		c.CertificateProviders = map[string]certificateProviderConfig{
@@ -215,9 +216,10 @@ func getFromMetadata(urlStr string) ([]byte, error) {
 }
 
 type config struct {
-	XdsServers           []server                             `json:"xds_servers,omitempty"`
-	Node                 *node                                `json:"node,omitempty"`
-	CertificateProviders map[string]certificateProviderConfig `json:"certificate_providers,omitempty"`
+	XdsServers               []server                             `json:"xds_servers,omitempty"`
+	Node                     *node                                `json:"node,omitempty"`
+	CertificateProviders     map[string]certificateProviderConfig `json:"certificate_providers,omitempty"`
+	GRPCServerResourceNameId string                               `json:"grpc_server_resource_name_id,omitempty"`
 }
 
 type server struct {

--- a/main_test.go
+++ b/main_test.go
@@ -62,7 +62,8 @@ func TestGenerate(t *testing.T) {
     "locality": {
       "zone": "uscentral-5"
     }
-  }
+  },
+  "grpc_server_resource_name_id": "grpc/server"
 }`,
 		},
 		{
@@ -107,7 +108,8 @@ func TestGenerate(t *testing.T) {
         "refresh_interval": "600s"
       }
     }
-  }
+  },
+  "grpc_server_resource_name_id": "grpc/server"
 }`,
 		},
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -33,7 +33,7 @@ func TestGenerate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			desc: "happy case without file watcher config",
+			desc: "happy case",
 			input: configInput{
 				xdsServerUri:     "example.com:443",
 				gcpProjectNumber: 123456789012345,
@@ -62,19 +62,19 @@ func TestGenerate(t *testing.T) {
     "locality": {
       "zone": "uscentral-5"
     }
-  },
-  "grpc_server_resource_name_id": "grpc/server"
+  }
 }`,
 		},
 		{
-			desc: "happy case file watcher config",
+			desc: "happy case with security config",
 			input: configInput{
-				xdsServerUri:       "example.com:443",
-				gcpProjectNumber:   123456789012345,
-				vpcNetworkName:     "thedefault",
-				ip:                 "10.9.8.7",
-				zone:               "uscentral-5",
-				includePSMSecurity: true,
+				xdsServerUri:            "example.com:443",
+				gcpProjectNumber:        123456789012345,
+				vpcNetworkName:          "thedefault",
+				ip:                      "10.9.8.7",
+				zone:                    "uscentral-5",
+				includePSMSecurity:      true,
+				includeServerResourceID: true,
 			},
 			wantOutput: `{
   "xds_servers": [


### PR DESCRIPTION
This value will be used as the `id` in the `resource_names` field of the LDS request, with `context_params` containing the listening IP:Port.