### PR TITLE
Update Node proto to work with v2 and v3 xDS implementations in TD.

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,10 +40,6 @@ var (
 	includeServerResourceID = flag.Bool("include-server-resource-id", false, "whether or not to generate config for server resource id. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 )
 
-// The `id` field of the Node proto is set to a value of the format
-// `projects/{project number}/networks/{network name}/nodes/{uuid}`.
-const nodeIDFormatStr = "projects/%d/networks/%s/nodes/%s"
-
 func main() {
 	flag.Parse()
 	if *gcpProjectNumber == 0 {
@@ -129,7 +125,7 @@ func generate(in configInput) ([]byte, error) {
 		// v3 implementation expects these in the former. Once we stop supporting
 		// v2, we can get rid of these metadata entries.
 		Node: &node{
-			Id:      fmt.Sprintf(nodeIDFormatStr, in.gcpProjectNumber, in.vpcNetworkName, uuid.New().String()),
+			Id:      fmt.Sprintf("projects/%d/networks/%s/nodes/%s", in.gcpProjectNumber, in.vpcNetworkName, uuid.New().String()),
 			Cluster: "cluster", // unused by TD
 			Locality: &locality{
 				Zone: in.zone,

--- a/main_test.go
+++ b/main_test.go
@@ -53,9 +53,10 @@ func TestGenerate(t *testing.T) {
     }
   ],
   "node": {
-    "id": "52fdfc07-2182-454f-963f-5f0f9a621d72~10.9.8.7",
+    "id": "projects/123456789012345/networks/thedefault/nodes/52fdfc07-2182-454f-963f-5f0f9a621d72",
     "cluster": "cluster",
     "metadata": {
+      "INSTANCE_IP": "10.9.8.7",
       "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
       "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
     },
@@ -88,9 +89,10 @@ func TestGenerate(t *testing.T) {
     }
   ],
   "node": {
-    "id": "52fdfc07-2182-454f-963f-5f0f9a621d72~10.9.8.7",
+    "id": "projects/123456789012345/networks/thedefault/nodes/52fdfc07-2182-454f-963f-5f0f9a621d72",
     "cluster": "cluster",
     "metadata": {
+      "INSTANCE_IP": "10.9.8.7",
       "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
       "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
     },

--- a/main_test.go
+++ b/main_test.go
@@ -53,10 +53,9 @@ func TestGenerate(t *testing.T) {
     }
   ],
   "node": {
-    "id": "projects/123456789012345/networks/thedefault/nodes/52fdfc07-2182-454f-963f-5f0f9a621d72",
+    "id": "52fdfc07-2182-454f-963f-5f0f9a621d72~10.9.8.7",
     "cluster": "cluster",
     "metadata": {
-      "INSTANCE_IP": "10.9.8.7",
       "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
       "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
     },
@@ -67,15 +66,14 @@ func TestGenerate(t *testing.T) {
 }`,
 		},
 		{
-			desc: "happy case with security config",
+			desc: "happy case with v3 config",
 			input: configInput{
-				xdsServerUri:            "example.com:443",
-				gcpProjectNumber:        123456789012345,
-				vpcNetworkName:          "thedefault",
-				ip:                      "10.9.8.7",
-				zone:                    "uscentral-5",
-				includePSMSecurity:      true,
-				includeServerResourceID: true,
+				xdsServerUri:      "example.com:443",
+				gcpProjectNumber:  123456789012345,
+				vpcNetworkName:    "thedefault",
+				ip:                "10.9.8.7",
+				zone:              "uscentral-5",
+				includeV3Features: true,
 			},
 			wantOutput: `{
   "xds_servers": [
@@ -89,7 +87,7 @@ func TestGenerate(t *testing.T) {
     }
   ],
   "node": {
-    "id": "projects/123456789012345/networks/thedefault/nodes/52fdfc07-2182-454f-963f-5f0f9a621d72",
+    "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
     "cluster": "cluster",
     "metadata": {
       "INSTANCE_IP": "10.9.8.7",

--- a/main_test.go
+++ b/main_test.go
@@ -97,6 +97,42 @@ func TestGenerate(t *testing.T) {
     "locality": {
       "zone": "uscentral-5"
     }
+  }
+}`,
+		},
+		{
+			desc: "happy case with v3 and security config",
+			input: configInput{
+				xdsServerUri:       "example.com:443",
+				gcpProjectNumber:   123456789012345,
+				vpcNetworkName:     "thedefault",
+				ip:                 "10.9.8.7",
+				zone:               "uscentral-5",
+				includeV3Features:  true,
+				includePSMSecurity: true,
+			},
+			wantOutput: `{
+  "xds_servers": [
+    {
+      "server_uri": "example.com:443",
+      "channel_creds": [
+        {
+          "type": "google_default"
+        }
+      ]
+    }
+  ],
+  "node": {
+    "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
+    "cluster": "cluster",
+    "metadata": {
+      "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
+      "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
+    },
+    "locality": {
+      "zone": "uscentral-5"
+    }
   },
   "certificate_providers": {
     "google_cloud_private_spiffe": {


### PR DESCRIPTION
We are interested in the following pieces of information in the `Node` proto:
- network name
- project number
- local IP
- a unique node id

Today (for v2 implementation in TD), these are conveyed as follows:
- local IP and unique node id are encoded in `node.id`
- network and project are sent as `node.metadata` entries

Going forward, we want to do the following:
- Pass network, project and unique node id in the `node.id` field in the format: `projects/{project number}/networks/{network name}/nodes/{id}`
- also continue to send network and project as `node.metadata` entries
- send local IP in `network.metadata` with key `INSTANCE_IP`
