### PR TITLE
Add deployment info as part of Node metadata

### DIFF
--- a/deployment_info.go
+++ b/deployment_info.go
@@ -1,0 +1,62 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type deploymentType int
+
+const (
+	deploymentTypeUnknown deploymentType = iota
+	deploymentTypeGKE
+	deploymentTypeGCE
+)
+
+// getDeploymentType tries to talk the metadata server at
+// http://metadata.google.internal and uses a response header with key "Server"
+// to determine the deployment type.
+func getDeploymentType() deploymentType {
+	parsedUrl, err := url.Parse("http://metadata.google.internal")
+	if err != nil {
+		return deploymentTypeUnknown
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	req := &http.Request{
+		Method: "GET",
+		URL:    parsedUrl,
+		Header: http.Header{"Metadata-Flavor": {"Google"}},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return deploymentTypeUnknown
+	}
+	resp.Body.Close()
+
+	// Read the "Server" header to determine the deployment type.
+	vals := resp.Header.Values("Server")
+	for _, val := range vals {
+		switch val {
+		case "GKE Metadata Server":
+			return deploymentTypeGKE
+		case "Metadata Server for VM":
+			return deploymentTypeGCE
+		}
+	}
+	return deploymentTypeUnknown
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module td-grpc-bootstrap
 go 1.13
 
 require (
-	github.com/google/go-cmp v0.5.2
-	github.com/google/uuid v1.1.1
+	github.com/google/go-cmp v0.5.4
+	github.com/google/uuid v1.1.2
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
-github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
-github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -280,15 +280,11 @@ var readHostNameFile = func() ([]byte, error) {
 }
 
 func getPodName() string {
-	if pod := os.Getenv("HOSTNAME"); pod != "" {
-		return pod
-	}
-	contents, err := readHostNameFile()
+	pod, err := os.Hostname()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not discover GKE pod name: %v", err)
-		return ""
 	}
-	return string(contents)
+	return pod
 }
 
 func getVMName() string {

--- a/main.go
+++ b/main.go
@@ -42,10 +42,10 @@ var (
 	includePSMSecurity    = flag.Bool("include-psm-security-experimental", false, "whether or not to generate config required for PSM security. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	secretsDir            = flag.String("secrets-dir-experimental", "/var/run/secrets/workload-spiffe-credentials", "path to a directory containing TLS certificates and keys required for PSM security. Used only if --include-psm-security-experimental is set. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	includeDeploymentInfo = flag.Bool("include-deployment-info-experimental", false, "whether or not to generate config which contains deployment related information. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	gkeClusterName        = flag.String("gke-cluster-name", "", "GKE cluster name to use, instead of retrieving it from the metadata server")
-	gkePodName            = flag.String("gke-pod-name", "", "GKE pod name to use, instead of reading it from $HOSTNAME or /etc/hostname file")
-	gkeNamespace          = flag.String("gke-namespace", "", "GKE namespace to use")
-	gcpVM                 = flag.String("gcp-vm", "", "GCP VM name to use, instead of reading it from the metadata server")
+	gkeClusterName        = flag.String("gke-cluster-name-experimental", "", "GKE cluster name to use, instead of retrieving it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	gkePodName            = flag.String("gke-pod-name-experimental", "", "GKE pod name to use, instead of reading it from $HOSTNAME or /etc/hostname file. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	gkeNamespace          = flag.String("gke-namespace-experimental", "", "GKE namespace to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	gceVM                 = flag.String("gce-vm-experimental", "", "GCE VM name to use, instead of reading it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 )
 
 func main() {
@@ -99,12 +99,12 @@ func main() {
 				"GKE-NAMESPACE": *gkeNamespace,
 			}
 		case deploymentTypeGCE:
-			vmName := *gcpVM
+			vmName := *gceVM
 			if vmName == "" {
 				vmName = getVMName()
 			}
 			deploymentInfo = map[string]string{
-				"GCP-VM":      vmName,
+				"GCE-VM":      vmName,
 				"GCP-ZONE":    zone,
 				"INSTANCE-IP": ip,
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -174,7 +174,7 @@ func TestGenerate(t *testing.T) {
 					"GKE-NAMESPACE": "test-gke-namespace",
 					"GKE-POD":       "test-gke-pod",
 					"INSTANCE-IP":   "10.9.8.7",
-					"GKE-VM":        "test-gce-vm",
+					"GCE-VM":        "test-gce-vm",
 				},
 			},
 			wantOutput: `{
@@ -199,11 +199,11 @@ func TestGenerate(t *testing.T) {
       "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
       "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault",
       "TRAFFIC_DIRECTOR_CLIENT_ENVIRONMENT": {
+        "GCE-VM": "test-gce-vm",
         "GCP-ZONE": "uscentral-5",
         "GKE-CLUSTER": "test-gke-cluster",
         "GKE-NAMESPACE": "test-gke-namespace",
         "GKE-POD": "test-gke-pod",
-        "GKE-VM": "test-gce-vm",
         "INSTANCE-IP": "10.9.8.7"
       }
     },

--- a/main_test.go
+++ b/main_test.go
@@ -16,12 +16,10 @@ package main
 
 import (
 	"context"
-	"errors"
 	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -291,62 +289,6 @@ func TestGetClusterName(t *testing.T) {
 		})
 	if got := getClusterName(); got != want {
 		t.Fatalf("getClusterName() = %s, want: %s", got, want)
-	}
-}
-
-func TestGetPodName(t *testing.T) {
-	tests := []struct {
-		name  string
-		setup func(t *testing.T)
-		want  string
-	}{
-		{
-			name: "no-env-var-no-hostname-file",
-			setup: func(t *testing.T) {
-				if err := os.Setenv("HOSTNAME", ""); err != nil {
-					t.Fatalf("failed to set env var HOSTNAME: %v", err)
-				}
-				readHostNameFile = func() ([]byte, error) { return nil, errors.New("failed to read hostname file") }
-			},
-			want: "",
-		},
-		{
-			name: "no-env-var-valid-hostname-file-contents",
-			setup: func(t *testing.T) {
-				if err := os.Setenv("HOSTNAME", ""); err != nil {
-					t.Fatalf("failed to set env var HOSTNAME: %v", err)
-				}
-				readHostNameFile = func() ([]byte, error) { return []byte("test-hostname1"), nil }
-			},
-			want: "test-hostname1",
-		},
-		{
-			name: "valid-env-var",
-			setup: func(t *testing.T) {
-				if err := os.Setenv("HOSTNAME", "test-hostname2"); err != nil {
-					t.Fatalf("failed to set env var HOSTNAME: %v", err)
-				}
-				// To ensure that a valid env var is preferred over reading the file.
-				readHostNameFile = func() ([]byte, error) { return nil, errors.New("failed to read hostname file") }
-			},
-			want: "test-hostname2",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			oldHostNameEnvVar := os.Getenv("HOSTNAME")
-			oldReadHostNameFile := readHostNameFile
-			defer func() {
-				os.Setenv("HOSTNAME", oldHostNameEnvVar)
-				readHostNameFile = oldReadHostNameFile
-			}()
-
-			test.setup(t)
-			if got := getPodName(); got != test.want {
-				t.Fatalf("getPodName() = %s, want %s", got, test.want)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
Summary of changes
- Identify the deployment type by talking to the Metadata server
- Add command line flags for deployment information that we plan to add to the `Node` metadata
- Talk to Metadata server and retrieve deployment information when the same is not specified on the command line