### PR TITLE
Add --config-scope-experimental flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ var (
 	gkePodName            = flag.String("gke-pod-name-experimental", "", "GKE pod name to use, instead of reading it from $HOSTNAME or /etc/hostname file. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	gkeNamespace          = flag.String("gke-namespace-experimental", "", "GKE namespace to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	gceVM                 = flag.String("gce-vm-experimental", "", "GCE VM name to use, instead of reading it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	routerScope           = flag.String("router-scope-experimental", "", "Scope name to use in conjunction with Router resources. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	configScope           = flag.String("config-scope-experimental", "", "Scope dictating which application networking configuration to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 )
 
 func main() {
@@ -123,7 +123,7 @@ func main() {
 		secretsDir:         *secretsDir,
 		metadataLabels:     nodeMetadata,
 		deploymentInfo:     deploymentInfo,
-		routerScope:        *routerScope,
+		configScope:        *configScope,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to generate config: %s\n", err)
@@ -167,7 +167,7 @@ type configInput struct {
 	secretsDir         string
 	metadataLabels     map[string]string
 	deploymentInfo     map[string]string
-	routerScope        string
+	configScope        string
 }
 
 func generate(in configInput) ([]byte, error) {
@@ -193,8 +193,8 @@ func generate(in configInput) ([]byte, error) {
 		},
 	}
 
-	if in.routerScope != "" {
-		c.Node.Metadata["TRAFFICDIRECTOR_SCOPE_NAME"] = in.routerScope
+	if in.configScope != "" {
+		c.Node.Metadata["TRAFFICDIRECTOR_SCOPE_NAME"] = in.configScope
 	}
 
 	for k, v := range in.metadataLabels {
@@ -205,8 +205,8 @@ func generate(in configInput) ([]byte, error) {
 		// the metadata field while the v3 implementation expects these in the id
 		// field.
 		var networkIdentifier string
-		if in.routerScope != "" {
-			networkIdentifier = fmt.Sprintf("scope:%s", in.routerScope)
+		if in.configScope != "" {
+			networkIdentifier = fmt.Sprintf("scope:%s", in.configScope)
 		} else {
 			networkIdentifier = in.vpcNetworkName
 		}

--- a/main.go
+++ b/main.go
@@ -182,7 +182,7 @@ func validate(in configInput) error {
 	re := regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]{0,63}$`)
 	if in.configScope != "" && !re.MatchString(in.configScope) {
 		return fmt.Errorf("config-scope may only contain letters, numbers, and '-'. " +
-			"It must begin with a letter and must exceed 64 characters in length")
+			"It must begin with a letter and must not exceed 64 characters in length")
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -221,12 +221,11 @@ func generate(in configInput) ([]byte, error) {
 		// xDS v2 implementation in TD expects the projectNumber and networkName in
 		// the metadata field while the v3 implementation expects these in the id
 		// field.
-		var networkIdentifier string
+		networkIdentifier := in.vpcNetworkName
 		if in.configScope != "" {
 			networkIdentifier = fmt.Sprintf("scope:%s", in.configScope)
-		} else {
-			networkIdentifier = in.vpcNetworkName
 		}
+
 		c.Node.Id = fmt.Sprintf("projects/%d/networks/%s/nodes/%s", in.gcpProjectNumber, networkIdentifier, uuid.New().String())
 		// xDS v2 implementation in TD expects the IP address to be encoded in the
 		// id field while the v3 implementation expects this in the metadata.

--- a/main.go
+++ b/main.go
@@ -181,8 +181,7 @@ type configInput struct {
 func validate(in configInput) error {
 	re := regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]{0,63}$`)
 	if in.configScope != "" && !re.MatchString(in.configScope) {
-		return fmt.Errorf("config-scope may only contain letters, numbers, and '-'. " +
-			"It must begin with a letter and must not exceed 64 characters in length")
+		return fmt.Errorf("config-scope may only contain letters, numbers, and '-'. It must begin with a letter and must not exceed 64 characters in length")
 	}
 
 	return nil

--- a/main_test.go
+++ b/main_test.go
@@ -46,7 +46,8 @@ func TestValidate(t *testing.T) {
 				includeV3Features: true,
 				configScope:       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
-			wantError: errors.New("config-scope must not exceed 64 characters. Current length: 67\n"),
+			wantError: errors.New("config-scope may only contain letters, numbers, and '-'. " +
+				"It must begin with a letter and must exceed 64 characters in length"),
 		},
 		{
 			desc: "fails when config-scope does not start with an alphabetic letter",
@@ -60,7 +61,8 @@ func TestValidate(t *testing.T) {
 				includeV3Features: true,
 				configScope:       "4foo",
 			},
-			wantError: errors.New("config-scope must begin with a letter\n"),
+			wantError: errors.New("config-scope may only contain letters, numbers, and '-'. " +
+				"It must begin with a letter and must exceed 64 characters in length"),
 		},
 		{
 			desc: "fails when config-scope contains characters besides letters, numbers, and hyphens.",
@@ -74,7 +76,8 @@ func TestValidate(t *testing.T) {
 				includeV3Features: true,
 				configScope:       "h*x8",
 			},
-			wantError: errors.New("config-scope must only contain letters, numbers, or '-'. Found '*'.\n"),
+			wantError: errors.New("config-scope may only contain letters, numbers, and '-'. " +
+				"It must begin with a letter and must exceed 64 characters in length"),
 		},
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"net"
 	"net/http"
@@ -81,8 +80,8 @@ func TestValidate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			err := validate(test.input)
-			if test.wantError != fmt.Sprint(err) {
-				t.Fatalf("validate(%+v) returned output does not match expected:\nWant: \"%s\"\nGot: \"%s\"", test.input, test.wantError, fmt.Sprint(err))
+			if test.wantError != err.Error() {
+				t.Fatalf("validate(%+v) returned output does not match expected:\nGot: \"%v\"\nWant: \"%s\"", test.input, err.Error(), test.wantError)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -213,6 +213,98 @@ func TestGenerate(t *testing.T) {
   }
 }`,
 		},
+		{
+			desc: "routerScope specified",
+			input: configInput{
+				xdsServerUri:      "example.com:443",
+				gcpProjectNumber:  123456789012345,
+				vpcNetworkName:    "thedefault",
+				ip:                "10.9.8.7",
+				zone:              "uscentral-5",
+				includeV3Features: true,
+				deploymentInfo: map[string]string{
+					"GCP-ZONE":      "uscentral-5",
+					"GKE-CLUSTER":   "test-gke-cluster",
+					"GKE-NAMESPACE": "test-gke-namespace",
+					"GKE-POD":       "test-gke-pod",
+					"INSTANCE-IP":   "10.9.8.7",
+					"GCE-VM":        "test-gce-vm",
+				},
+				routerScope: "testscope",
+			},
+			wantOutput: `{
+  "xds_servers": [
+    {
+      "server_uri": "example.com:443",
+      "channel_creds": [
+        {
+          "type": "google_default"
+        }
+      ],
+      "server_features": [
+        "xds_v3"
+      ]
+    }
+  ],
+  "node": {
+    "id": "projects/123456789012345/networks/scope:testscope/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
+    "cluster": "cluster",
+    "metadata": {
+      "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
+      "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault",
+      "TRAFFICDIRECTOR_SCOPE_NAME": "testscope",
+      "TRAFFIC_DIRECTOR_CLIENT_ENVIRONMENT": {
+        "GCE-VM": "test-gce-vm",
+        "GCP-ZONE": "uscentral-5",
+        "GKE-CLUSTER": "test-gke-cluster",
+        "GKE-NAMESPACE": "test-gke-namespace",
+        "GKE-POD": "test-gke-pod",
+        "INSTANCE-IP": "10.9.8.7"
+      }
+    },
+    "locality": {
+      "zone": "uscentral-5"
+    }
+  }
+}`,
+		},
+		{
+			desc: "routerScope specified with v2 config",
+			input: configInput{
+				xdsServerUri:      "example.com:443",
+				gcpProjectNumber:  123456789012345,
+				vpcNetworkName:    "thedefault",
+				ip:                "10.9.8.7",
+				zone:              "uscentral-5",
+				includeV3Features: false,
+				routerScope:       "testscope",
+			},
+			wantOutput: `{
+  "xds_servers": [
+    {
+      "server_uri": "example.com:443",
+      "channel_creds": [
+        {
+          "type": "google_default"
+        }
+      ]
+    }
+  ],
+  "node": {
+    "id": "52fdfc07-2182-454f-963f-5f0f9a621d72~10.9.8.7",
+    "cluster": "cluster",
+    "metadata": {
+      "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
+      "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault",
+      "TRAFFICDIRECTOR_SCOPE_NAME": "testscope"
+    },
+    "locality": {
+      "zone": "uscentral-5"
+    }
+  }
+}`,
+		},
 	}
 
 	for _, test := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -47,7 +47,7 @@ func TestValidate(t *testing.T) {
 				configScope:       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
 			wantError: errors.New("config-scope may only contain letters, numbers, and '-'. " +
-				"It must begin with a letter and must exceed 64 characters in length"),
+				"It must begin with a letter and must not exceed 64 characters in length"),
 		},
 		{
 			desc: "fails when config-scope does not start with an alphabetic letter",
@@ -62,7 +62,7 @@ func TestValidate(t *testing.T) {
 				configScope:       "4foo",
 			},
 			wantError: errors.New("config-scope may only contain letters, numbers, and '-'. " +
-				"It must begin with a letter and must exceed 64 characters in length"),
+				"It must begin with a letter and must not exceed 64 characters in length"),
 		},
 		{
 			desc: "fails when config-scope contains characters besides letters, numbers, and hyphens.",
@@ -77,7 +77,7 @@ func TestValidate(t *testing.T) {
 				configScope:       "h*x8",
 			},
 			wantError: errors.New("config-scope may only contain letters, numbers, and '-'. " +
-				"It must begin with a letter and must exceed 64 characters in length"),
+				"It must begin with a letter and must not exceed 64 characters in length"),
 		},
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -214,7 +214,7 @@ func TestGenerate(t *testing.T) {
 }`,
 		},
 		{
-			desc: "routerScope specified",
+			desc: "configScope specified",
 			input: configInput{
 				xdsServerUri:      "example.com:443",
 				gcpProjectNumber:  123456789012345,
@@ -230,7 +230,7 @@ func TestGenerate(t *testing.T) {
 					"INSTANCE-IP":   "10.9.8.7",
 					"GCE-VM":        "test-gce-vm",
 				},
-				routerScope: "testscope",
+				configScope: "testscope",
 			},
 			wantOutput: `{
   "xds_servers": [
@@ -270,7 +270,7 @@ func TestGenerate(t *testing.T) {
 }`,
 		},
 		{
-			desc: "routerScope specified with v2 config",
+			desc: "configScope specified with v2 config",
 			input: configInput{
 				xdsServerUri:      "example.com:443",
 				gcpProjectNumber:  123456789012345,
@@ -278,7 +278,7 @@ func TestGenerate(t *testing.T) {
 				ip:                "10.9.8.7",
 				zone:              "uscentral-5",
 				includeV3Features: false,
-				routerScope:       "testscope",
+				configScope:       "testscope",
 			},
 			wantOutput: `{
   "xds_servers": [


### PR DESCRIPTION
The AppNet APIs introduce a `scope` field independent of VPC network. This PR introduces a flag enabling the bootstrap file to select a particular scope.