### PR TITLE
Drop xDS v2 support from bootstrap generator

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,10 +216,6 @@ func generate(in configInput) ([]byte, error) {
 		},
 	}
 
-	if in.configScope != "" {
-		c.Node.Metadata["TRAFFICDIRECTOR_SCOPE_NAME"] = in.configScope
-	}
-
 	for k, v := range in.metadataLabels {
 		c.Node.Metadata[k] = v
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -314,7 +314,6 @@ func TestGenerate(t *testing.T) {
       "INSTANCE_IP": "10.9.8.7",
       "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
       "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault",
-      "TRAFFICDIRECTOR_SCOPE_NAME": "testscope",
       "TRAFFIC_DIRECTOR_CLIENT_ENVIRONMENT": {
         "GCE-VM": "test-gce-vm",
         "GCP-ZONE": "uscentral-5",
@@ -357,8 +356,7 @@ func TestGenerate(t *testing.T) {
     "cluster": "cluster",
     "metadata": {
       "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
-      "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault",
-      "TRAFFICDIRECTOR_SCOPE_NAME": "testscope"
+      "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
     },
     "locality": {
       "zone": "uscentral-5"


### PR DESCRIPTION
App Net will no longer be supporting xDS V2, so we drop the v2-compatible method of supplying scope in the bootstrap.

@ejona86 @easwars 