### PR TITLE
Update REAME: link our public Docker image && a minimum usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ Traffic Director is available on the [Google Cloud
 website](https://cloud.google.com/traffic-director/).
 
 [gRFC A27]: https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md
+
+## Public Docker Image
+
+Built Docker image is publicly available at Google Container Registry:
+gcr.io/trafficdirector-prod/td-grpc-bootstrap
+
+Please refer to the [GKE setup guide](https://cloud.google.com/traffic-director/docs/set-up-proxyless-gke)
+for more details.


### PR DESCRIPTION
The motivation of this PR is https://hub.docker.com/r/sevki/td-grpc-bootstrap. I think we should be explicit about the GCR maintained by us officially.

@ejona86 