### PR TITLE
add basic support for federation

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -364,6 +364,51 @@ func TestGenerate(t *testing.T) {
   }
 }`,
 		},
+		{
+			desc: "happy case with federation",
+			input: configInput{
+				xdsServerUri:      "example.com:443",
+				gcpProjectNumber:  123456789012345,
+				vpcNetworkName:    "thedefault",
+				ip:                "10.9.8.7",
+				zone:              "uscentral-5",
+				metadataLabels:    map[string]string{"k1": "v1", "k2": "v2"},
+				includeV3Features: true,
+				includeFederation: true,
+			},
+			wantOutput: `{
+  "xds_servers": [
+    {
+      "server_uri": "example.com:443",
+      "channel_creds": [
+        {
+          "type": "google_default"
+        }
+      ],
+      "server_features": [
+        "xds_v3"
+      ]
+    }
+  ],
+  "authorities": {
+    "": {}
+  },
+  "node": {
+    "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
+    "cluster": "cluster",
+    "metadata": {
+      "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
+      "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault",
+      "k1": "v1",
+      "k2": "v2"
+    },
+    "locality": {
+      "zone": "uscentral-5"
+    }
+  }
+}`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Federation support in grpc is described [here](https://github.com/grpc/proposal/blob/master/A47-xds-federation.md)

This PR does the following:
- introduces a `--include-federation-experimental` flag to enable generation of configs to support federation. 
- adds an entry to the `authorities` map with the empty string as key, and an empty `xds_servers` field.
  - any resources using new-style names with without an authority will match this entry and will use the same configuration as that of the top-level `xds_servers` field.

In a follow-up PR, I will add support (via another command line flag) for the user to specify a JSON representation of the configuration for the `authorities` field. This will enable them to use custom authorities.