### PR TITLE
Use Go 1.18 in CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.14
+          go-version: 1.18
 
       - name: Run tests
         run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/td-grpc-bootstrap
+/td-grpc-bootstrap-*.tar.gz

--- a/tools/cloudbuild-artifacts.yaml
+++ b/tools/cloudbuild-artifacts.yaml
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 steps:
-- name: golang:1.14-alpine
+- name: golang:1.18-alpine
   args: ['go', 'build', './...']
-- name: golang:1.14-alpine
+- name: golang:1.18-alpine
   args: ['go', 'test', './...']
 - name: alpine
   args: ['./tools/package.sh', '$COMMIT_SHA']


### PR DESCRIPTION
Go 1.18 includes VCS information within the binary so it is easy to
determine the git commit the binary was built with using `go version
-m`. Go considers the VCS modified if there are unknown files, so add
gitignore to avoid causing the build to be considered dirty.