### PR TITLE
Use non-Alpine image on Cloud Build CI

### DIFF
--- a/tools/cloudbuild-artifacts.yaml
+++ b/tools/cloudbuild-artifacts.yaml
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 steps:
-- name: golang:1.18-alpine
+- name: golang:1.18
   args: ['go', 'build', './...']
-- name: golang:1.18-alpine
+- name: golang:1.18
   args: ['go', 'test', './...']
 - name: alpine
   args: ['./tools/package.sh', '$COMMIT_SHA']


### PR DESCRIPTION
This fixes a regression introduced in 9f045adb that broke the Cloud
Build CI:

```
Step #0: go: missing Git command. See https://golang.org/s/gogetcmd
Step #0: error obtaining VCS status: exec: "git": executable file not found in $PATH
Step #0: 	Use -buildvcs=false to disable VCS stamping.
```

In Go 1.18 the Go command will invoke the git command to include VCS
information inside the binary. We want that functionality, so we don't
want to pass `-buildvcs=false`. The non-Alpine container includes the
git command.