### PR TITLE
Changes to support xDS Federation

### DIFF
--- a/main.go
+++ b/main.go
@@ -394,11 +394,6 @@ type creds struct {
 	Config interface{} `json:"config,omitempty"`
 }
 
-type authority struct {
-	ClientListenerResourceNameTemplate string   `json:"client_listener_resource_name_template,omitempty"`
-	XdsServers                         []server `json:"xds_servers,omitempty"`
-}
-
 type node struct {
 	Id           string                 `json:"id,omitempty"`
 	Cluster      string                 `json:"cluster,omitempty"`

--- a/main.go
+++ b/main.go
@@ -265,8 +265,9 @@ func generate(in configInput) ([]byte, error) {
 	}
 
 	if in.includeFederationSupport {
-		// Authorities with an empty server config will end up using the top-level server config.
-		// For more details, see: https://github.com/grpc/proposal/blob/master/A47-xds-federation.md#bootstrap-config-changes.
+		// Authorities with an empty server config will end up using
+		// the top-level server config. For more details, see:
+		// https://github.com/grpc/proposal/blob/master/A47-xds-federation.md#bootstrap-config-changes.
 		c.Authorities = map[string]struct{}{
 			tdURI: {},
 			"":    {},

--- a/main.go
+++ b/main.go
@@ -267,7 +267,7 @@ func generate(in configInput) ([]byte, error) {
 	// Check for include XDS Federation flag to include Authorities in bootstrap config
 	if in.includeXDSFederation {
 		// both entries point to {} which is the top-level xds server config
-		c.Authorities = map[string]authority{
+		c.Authorities = map[string]struct{}{
 			// for new style resource names which explicitly specify TD
 			TdUri: {},
 			// for all new style resource names which contain no authority
@@ -377,7 +377,7 @@ func getFromMetadata(urlStr string) ([]byte, error) {
 
 type config struct {
 	XdsServers                         []server                             `json:"xds_servers,omitempty"`
-	Authorities                        map[string]authority                 `json:"authorities,omitempty"`
+	Authorities                        map[string]struct{}                  `json:"authorities,omitempty"`
 	Node                               *node                                `json:"node,omitempty"`
 	CertificateProviders               map[string]certificateProviderConfig `json:"certificate_providers,omitempty"`
 	ServerListenerResourceNameTemplate string                               `json:"server_listener_resource_name_template,omitempty"`

--- a/main.go
+++ b/main.go
@@ -32,25 +32,25 @@ import (
 	"github.com/google/uuid"
 )
 
-const TdUri = "trafficdirector.googleapis.com:443"
+const tdURI = "trafficdirector.googleapis.com:443"
 
 var (
-	xdsServerUri                = flag.String("xds-server-uri", TdUri, "override of server uri, for testing")
-	outputName                  = flag.String("output", "-", "output file name")
-	gcpProjectNumber            = flag.Int64("gcp-project-number", 0, "the gcp project number. If unknown, can be found via 'gcloud projects list'")
-	vpcNetworkName              = flag.String("vpc-network-name", "default", "VPC network name")
-	localityZone                = flag.String("locality-zone", "", "the locality zone to use, instead of retrieving it from the metadata server. Useful when not running on GCP and/or for testing")
-	ignoreResourceDeletion      = flag.Bool("ignore-resource-deletion-experimental", false, "assume missing resources notify operators when using Traffic Director, as in gRFC A53. This is not currently the case. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	includeV3Features           = flag.Bool("include-v3-features-experimental", true, "whether or not to generate configs which works with the xDS v3 implementation in TD. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	includePSMSecurity          = flag.Bool("include-psm-security-experimental", true, "whether or not to generate config required for PSM security. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	secretsDir                  = flag.String("secrets-dir", "/var/run/secrets/workload-spiffe-credentials", "path to a directory containing TLS certificates and keys required for PSM security")
-	includeDeploymentInfo       = flag.Bool("include-deployment-info-experimental", false, "whether or not to generate config which contains deployment related information. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	gkeClusterName              = flag.String("gke-cluster-name-experimental", "", "GKE cluster name to use, instead of retrieving it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	gkePodName                  = flag.String("gke-pod-name-experimental", "", "GKE pod name to use, instead of reading it from $HOSTNAME or /etc/hostname file. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	gkeNamespace                = flag.String("gke-namespace-experimental", "", "GKE namespace to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	gceVM                       = flag.String("gce-vm-experimental", "", "GCE VM name to use, instead of reading it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	configMesh                  = flag.String("config-mesh-experimental", "", "Dictates which Mesh resource to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	includeXDSFederationSupport = flag.Bool("include-federation-support-experimental", false, "whether or not to generate configs required for xDS Federation. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	xdsServerUri             = flag.String("xds-server-uri", tdURI, "override of server uri, for testing")
+	outputName               = flag.String("output", "-", "output file name")
+	gcpProjectNumber         = flag.Int64("gcp-project-number", 0, "the gcp project number. If unknown, can be found via 'gcloud projects list'")
+	vpcNetworkName           = flag.String("vpc-network-name", "default", "VPC network name")
+	localityZone             = flag.String("locality-zone", "", "the locality zone to use, instead of retrieving it from the metadata server. Useful when not running on GCP and/or for testing")
+	ignoreResourceDeletion   = flag.Bool("ignore-resource-deletion-experimental", false, "assume missing resources notify operators when using Traffic Director, as in gRFC A53. This is not currently the case. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	includeV3Features        = flag.Bool("include-v3-features-experimental", true, "whether or not to generate configs which works with the xDS v3 implementation in TD. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	includePSMSecurity       = flag.Bool("include-psm-security-experimental", true, "whether or not to generate config required for PSM security. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	secretsDir               = flag.String("secrets-dir", "/var/run/secrets/workload-spiffe-credentials", "path to a directory containing TLS certificates and keys required for PSM security")
+	includeDeploymentInfo    = flag.Bool("include-deployment-info-experimental", false, "whether or not to generate config which contains deployment related information. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	gkeClusterName           = flag.String("gke-cluster-name-experimental", "", "GKE cluster name to use, instead of retrieving it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	gkePodName               = flag.String("gke-pod-name-experimental", "", "GKE pod name to use, instead of reading it from $HOSTNAME or /etc/hostname file. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	gkeNamespace             = flag.String("gke-namespace-experimental", "", "GKE namespace to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	gceVM                    = flag.String("gce-vm-experimental", "", "GCE VM name to use, instead of reading it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	configMesh               = flag.String("config-mesh-experimental", "", "Dictates which Mesh resource to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	includeFederationSupport = flag.Bool("include-federation-support-experimental", false, "whether or not to generate configs required for xDS Federation. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 )
 
 func main() {
@@ -123,19 +123,19 @@ func main() {
 	}
 
 	input := configInput{
-		xdsServerUri:           *xdsServerUri,
-		gcpProjectNumber:       *gcpProjectNumber,
-		vpcNetworkName:         *vpcNetworkName,
-		ip:                     ip,
-		zone:                   zone,
-		ignoreResourceDeletion: *ignoreResourceDeletion,
-		includeV3Features:      *includeV3Features,
-		includePSMSecurity:     *includePSMSecurity,
-		secretsDir:             *secretsDir,
-		metadataLabels:         nodeMetadata,
-		deploymentInfo:         deploymentInfo,
-		configMesh:             *configMesh,
-		includeXDSFederation:   *includeXDSFederationSupport,
+		xdsServerUri:             *xdsServerUri,
+		gcpProjectNumber:         *gcpProjectNumber,
+		vpcNetworkName:           *vpcNetworkName,
+		ip:                       ip,
+		zone:                     zone,
+		ignoreResourceDeletion:   *ignoreResourceDeletion,
+		includeV3Features:        *includeV3Features,
+		includePSMSecurity:       *includePSMSecurity,
+		secretsDir:               *secretsDir,
+		metadataLabels:           nodeMetadata,
+		deploymentInfo:           deploymentInfo,
+		configMesh:               *configMesh,
+		includeFederationSupport: *includeFederationSupport,
 	}
 
 	if err := validate(input); err != nil {
@@ -176,19 +176,19 @@ func main() {
 }
 
 type configInput struct {
-	xdsServerUri           string
-	gcpProjectNumber       int64
-	vpcNetworkName         string
-	ip                     string
-	zone                   string
-	ignoreResourceDeletion bool
-	includeV3Features      bool
-	includePSMSecurity     bool
-	secretsDir             string
-	metadataLabels         map[string]string
-	deploymentInfo         map[string]string
-	configMesh             string
-	includeXDSFederation   bool
+	xdsServerUri             string
+	gcpProjectNumber         int64
+	vpcNetworkName           string
+	ip                       string
+	zone                     string
+	ignoreResourceDeletion   bool
+	includeV3Features        bool
+	includePSMSecurity       bool
+	secretsDir               string
+	metadataLabels           map[string]string
+	deploymentInfo           map[string]string
+	configMesh               string
+	includeFederationSupport bool
 }
 
 func validate(in configInput) error {
@@ -264,14 +264,12 @@ func generate(in configInput) ([]byte, error) {
 		c.Node.Metadata["TRAFFIC_DIRECTOR_CLIENT_ENVIRONMENT"] = in.deploymentInfo
 	}
 
-	// Check for include XDS Federation flag to include Authorities in bootstrap config
-	if in.includeXDSFederation {
-		// both entries point to {} which is the top-level xds server config
+	if in.includeFederationSupport {
+		// Authorities with an empty server config will end up using the top-level server config.
+		// For more details, see: https://github.com/grpc/proposal/blob/master/A47-xds-federation.md#bootstrap-config-changes.
 		c.Authorities = map[string]struct{}{
-			// for new style resource names which explicitly specify TD
-			TdUri: {},
-			// for all new style resource names which contain no authority
-			"": {},
+			tdURI: {},
+			"":    {},
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -33,22 +33,23 @@ import (
 )
 
 var (
-	xdsServerUri     = flag.String("xds-server-uri", "trafficdirector.googleapis.com:443", "override of server uri, for testing")
-	outputName       = flag.String("output", "-", "output file name")
-	gcpProjectNumber = flag.Int64("gcp-project-number", 0,
-		"the gcp project number. If unknown, can be found via 'gcloud projects list'")
-	vpcNetworkName         = flag.String("vpc-network-name", "default", "VPC network name")
-	localityZone           = flag.String("locality-zone", "", "the locality zone to use, instead of retrieving it from the metadata server. Useful when not running on GCP and/or for testing")
-	ignoreResourceDeletion = flag.Bool("ignore-resource-deletion-experimental", false, "assume missing resources notify operators when using Traffic Director, as in gRFC A53. This is not currently the case. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	includeV3Features      = flag.Bool("include-v3-features-experimental", true, "whether or not to generate configs which works with the xDS v3 implementation in TD. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	includePSMSecurity     = flag.Bool("include-psm-security-experimental", true, "whether or not to generate config required for PSM security. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	secretsDir             = flag.String("secrets-dir", "/var/run/secrets/workload-spiffe-credentials", "path to a directory containing TLS certificates and keys required for PSM security")
-	includeDeploymentInfo  = flag.Bool("include-deployment-info-experimental", false, "whether or not to generate config which contains deployment related information. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	gkeClusterName         = flag.String("gke-cluster-name-experimental", "", "GKE cluster name to use, instead of retrieving it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	gkePodName             = flag.String("gke-pod-name-experimental", "", "GKE pod name to use, instead of reading it from $HOSTNAME or /etc/hostname file. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	gkeNamespace           = flag.String("gke-namespace-experimental", "", "GKE namespace to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	gceVM                  = flag.String("gce-vm-experimental", "", "GCE VM name to use, instead of reading it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	configMesh             = flag.String("config-mesh-experimental", "", "Dictates which Mesh resource to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	xdsServerUri                              = flag.String("xds-server-uri", "trafficdirector.googleapis.com:443", "override of server uri, for testing")
+	outputName                                = flag.String("output", "-", "output file name")
+	gcpProjectNumber                          = flag.Int64("gcp-project-number", 0, "the gcp project number. If unknown, can be found via 'gcloud projects list'")
+	vpcNetworkName                            = flag.String("vpc-network-name", "default", "VPC network name")
+	localityZone                              = flag.String("locality-zone", "", "the locality zone to use, instead of retrieving it from the metadata server. Useful when not running on GCP and/or for testing")
+	ignoreResourceDeletion                    = flag.Bool("ignore-resource-deletion-experimental", false, "assume missing resources notify operators when using Traffic Director, as in gRFC A53. This is not currently the case. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	includeV3Features                         = flag.Bool("include-v3-features-experimental", true, "whether or not to generate configs which works with the xDS v3 implementation in TD. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	includePSMSecurity                        = flag.Bool("include-psm-security-experimental", true, "whether or not to generate config required for PSM security. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	secretsDir                                = flag.String("secrets-dir", "/var/run/secrets/workload-spiffe-credentials", "path to a directory containing TLS certificates and keys required for PSM security")
+	includeDeploymentInfo                     = flag.Bool("include-deployment-info-experimental", false, "whether or not to generate config which contains deployment related information. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	gkeClusterName                            = flag.String("gke-cluster-name-experimental", "", "GKE cluster name to use, instead of retrieving it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	gkePodName                                = flag.String("gke-pod-name-experimental", "", "GKE pod name to use, instead of reading it from $HOSTNAME or /etc/hostname file. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	gkeNamespace                              = flag.String("gke-namespace-experimental", "", "GKE namespace to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	gceVM                                     = flag.String("gce-vm-experimental", "", "GCE VM name to use, instead of reading it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	configMesh                                = flag.String("config-mesh-experimental", "", "Dictates which Mesh resource to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	authorityName                             = flag.String("authority-name-experimental", "", "Authority name to be used for xDS Federation. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	clientDefaultListenerResourceNameTemplate = flag.String("client-default-listener-resource-name-template-experimental", "", "Client Default ListenerResourceName Template to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 )
 
 func main() {
@@ -133,6 +134,8 @@ func main() {
 		metadataLabels:         nodeMetadata,
 		deploymentInfo:         deploymentInfo,
 		configMesh:             *configMesh,
+		authorityName:          *authorityName,
+		clientDefaultListenerResourceNameTemplate: *clientDefaultListenerResourceNameTemplate,
 	}
 
 	if err := validate(input); err != nil {
@@ -173,18 +176,20 @@ func main() {
 }
 
 type configInput struct {
-	xdsServerUri           string
-	gcpProjectNumber       int64
-	vpcNetworkName         string
-	ip                     string
-	zone                   string
-	ignoreResourceDeletion bool
-	includeV3Features      bool
-	includePSMSecurity     bool
-	secretsDir             string
-	metadataLabels         map[string]string
-	deploymentInfo         map[string]string
-	configMesh             string
+	xdsServerUri                              string
+	gcpProjectNumber                          int64
+	vpcNetworkName                            string
+	ip                                        string
+	zone                                      string
+	ignoreResourceDeletion                    bool
+	includeV3Features                         bool
+	includePSMSecurity                        bool
+	secretsDir                                string
+	metadataLabels                            map[string]string
+	deploymentInfo                            map[string]string
+	configMesh                                string
+	authorityName                             string
+	clientDefaultListenerResourceNameTemplate string
 }
 
 func validate(in configInput) error {
@@ -258,6 +263,16 @@ func generate(in configInput) ([]byte, error) {
 	}
 	if in.deploymentInfo != nil {
 		c.Node.Metadata["TRAFFIC_DIRECTOR_CLIENT_ENVIRONMENT"] = in.deploymentInfo
+	}
+
+	if in.authorityName != "" {
+		c.Authorities = map[string]authority{
+			in.authorityName: {},
+		}
+	}
+
+	if in.clientDefaultListenerResourceNameTemplate != "" {
+		c.ClientDefaultListenerResourceNameTemplate = in.clientDefaultListenerResourceNameTemplate
 	}
 
 	return json.MarshalIndent(c, "", "  ")
@@ -361,10 +376,12 @@ func getFromMetadata(urlStr string) ([]byte, error) {
 }
 
 type config struct {
-	XdsServers                         []server                             `json:"xds_servers,omitempty"`
-	Node                               *node                                `json:"node,omitempty"`
-	CertificateProviders               map[string]certificateProviderConfig `json:"certificate_providers,omitempty"`
-	ServerListenerResourceNameTemplate string                               `json:"server_listener_resource_name_template,omitempty"`
+	XdsServers                                []server                             `json:"xds_servers,omitempty"`
+	Authorities                               map[string]authority                 `json:"authorities,omitempty"`
+	Node                                      *node                                `json:"node,omitempty"`
+	CertificateProviders                      map[string]certificateProviderConfig `json:"certificate_providers,omitempty"`
+	ServerListenerResourceNameTemplate        string                               `json:"server_listener_resource_name_template,omitempty"`
+	ClientDefaultListenerResourceNameTemplate string                               `json:"client_default_listener_resource_name_template,omitempty"`
 }
 
 type server struct {
@@ -376,6 +393,11 @@ type server struct {
 type creds struct {
 	Type   string      `json:"type,omitempty"`
 	Config interface{} `json:"config,omitempty"`
+}
+
+type authority struct {
+	ClientListenerResourceNameTemplate string   `json:"client_listener_resource_name_template,omitempty"`
+	XdsServers                         []server `json:"xds_servers,omitempty"`
 }
 
 type node struct {

--- a/main_test.go
+++ b/main_test.go
@@ -96,14 +96,13 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "happy case with v3 config by default",
 			input: configInput{
-				xdsServerUri:         "example.com:443",
-				gcpProjectNumber:     123456789012345,
-				vpcNetworkName:       "thedefault",
-				ip:                   "10.9.8.7",
-				zone:                 "uscentral-5",
-				metadataLabels:       map[string]string{"k1": "v1", "k2": "v2"},
-				includeV3Features:    true,
-				includeXDSFederation: true,
+				xdsServerUri:      "example.com:443",
+				gcpProjectNumber:  123456789012345,
+				vpcNetworkName:    "thedefault",
+				ip:                "10.9.8.7",
+				zone:              "uscentral-5",
+				metadataLabels:    map[string]string{"k1": "v1", "k2": "v2"},
+				includeV3Features: true,
 			},
 			wantOutput: `{
   "xds_servers": [
@@ -119,10 +118,6 @@ func TestGenerate(t *testing.T) {
       ]
     }
   ],
-  "authorities": {
-    "": {},
-    "trafficdirector.googleapis.com:443": {}
-  },
   "node": {
     "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
     "cluster": "cluster",
@@ -400,6 +395,90 @@ func TestGenerate(t *testing.T) {
     "cluster": "cluster",
     "metadata": {
       "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
+      "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
+    },
+    "locality": {
+      "zone": "uscentral-5"
+    }
+  }
+}`,
+		},
+
+		{
+			desc: "happy case with v3 defaults and federation support enabled",
+			input: configInput{
+				xdsServerUri:             "example.com:443",
+				gcpProjectNumber:         123456789012345,
+				vpcNetworkName:           "thedefault",
+				ip:                       "10.9.8.7",
+				zone:                     "uscentral-5",
+				includeV3Features:        true,
+				includeFederationSupport: true,
+			},
+			wantOutput: `{
+  "xds_servers": [
+    {
+      "server_uri": "example.com:443",
+      "channel_creds": [
+        {
+          "type": "google_default"
+        }
+      ],
+      "server_features": [
+        "xds_v3"
+      ]
+    }
+  ],
+  "authorities": {
+    "": {},
+    "trafficdirector.googleapis.com:443": {}
+  },
+  "node": {
+    "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
+    "cluster": "cluster",
+    "metadata": {
+      "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
+      "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
+    },
+    "locality": {
+      "zone": "uscentral-5"
+    }
+  }
+}`,
+		},
+
+		{
+			desc: "happy case with v2 config and federation support enabled",
+			input: configInput{
+				xdsServerUri:             "example.com:443",
+				gcpProjectNumber:         123456789012345,
+				vpcNetworkName:           "thedefault",
+				ip:                       "10.9.8.7",
+				zone:                     "uscentral-5",
+				includeV3Features:        false,
+				includeFederationSupport: true,
+			},
+			wantOutput: `{
+  "xds_servers": [
+    {
+      "server_uri": "example.com:443",
+      "channel_creds": [
+        {
+          "type": "google_default"
+        }
+      ]
+    }
+  ],
+  "authorities": {
+    "": {},
+    "trafficdirector.googleapis.com:443": {}
+  },
+  "node": {
+    "id": "52fdfc07-2182-454f-963f-5f0f9a621d72~10.9.8.7",
+    "cluster": "cluster",
+    "metadata": {
       "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
       "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
     },

--- a/main_test.go
+++ b/main_test.go
@@ -96,15 +96,14 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "happy case with v3 config by default",
 			input: configInput{
-				xdsServerUri:      "example.com:443",
-				gcpProjectNumber:  123456789012345,
-				vpcNetworkName:    "thedefault",
-				ip:                "10.9.8.7",
-				zone:              "uscentral-5",
-				metadataLabels:    map[string]string{"k1": "v1", "k2": "v2"},
-				includeV3Features: true,
-				authorityName:     "xds.authority.com",
-				clientDefaultListenerResourceNameTemplate: "xdstp://xds.authority.com/envoy.config.listener.v3.Listener/%s",
+				xdsServerUri:         "example.com:443",
+				gcpProjectNumber:     123456789012345,
+				vpcNetworkName:       "thedefault",
+				ip:                   "10.9.8.7",
+				zone:                 "uscentral-5",
+				metadataLabels:       map[string]string{"k1": "v1", "k2": "v2"},
+				includeV3Features:    true,
+				includeXDSFederation: true,
 			},
 			wantOutput: `{
   "xds_servers": [
@@ -121,7 +120,8 @@ func TestGenerate(t *testing.T) {
     }
   ],
   "authorities": {
-    "xds.authority.com": {}
+    "": {},
+    "trafficdirector.googleapis.com:443": {}
   },
   "node": {
     "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
@@ -136,8 +136,7 @@ func TestGenerate(t *testing.T) {
     "locality": {
       "zone": "uscentral-5"
     }
-  },
-  "client_default_listener_resource_name_template": "xdstp://xds.authority.com/envoy.config.listener.v3.Listener/%s"
+  }
 }`,
 		},
 		{

--- a/main_test.go
+++ b/main_test.go
@@ -404,7 +404,6 @@ func TestGenerate(t *testing.T) {
   }
 }`,
 		},
-
 		{
 			desc: "happy case with v3 defaults and federation support enabled",
 			input: configInput{
@@ -439,46 +438,6 @@ func TestGenerate(t *testing.T) {
     "cluster": "cluster",
     "metadata": {
       "INSTANCE_IP": "10.9.8.7",
-      "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
-      "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
-    },
-    "locality": {
-      "zone": "uscentral-5"
-    }
-  }
-}`,
-		},
-
-		{
-			desc: "happy case with v2 config and federation support enabled",
-			input: configInput{
-				xdsServerUri:             "example.com:443",
-				gcpProjectNumber:         123456789012345,
-				vpcNetworkName:           "thedefault",
-				ip:                       "10.9.8.7",
-				zone:                     "uscentral-5",
-				includeV3Features:        false,
-				includeFederationSupport: true,
-			},
-			wantOutput: `{
-  "xds_servers": [
-    {
-      "server_uri": "example.com:443",
-      "channel_creds": [
-        {
-          "type": "google_default"
-        }
-      ]
-    }
-  ],
-  "authorities": {
-    "": {},
-    "trafficdirector.googleapis.com:443": {}
-  },
-  "node": {
-    "id": "52fdfc07-2182-454f-963f-5f0f9a621d72~10.9.8.7",
-    "cluster": "cluster",
-    "metadata": {
       "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
       "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
     },

--- a/main_test.go
+++ b/main_test.go
@@ -103,6 +103,8 @@ func TestGenerate(t *testing.T) {
 				zone:              "uscentral-5",
 				metadataLabels:    map[string]string{"k1": "v1", "k2": "v2"},
 				includeV3Features: true,
+				authorityName:     "xds.authority.com",
+				clientDefaultListenerResourceNameTemplate: "xdstp://xds.authority.com/envoy.config.listener.v3.Listener/%s",
 			},
 			wantOutput: `{
   "xds_servers": [
@@ -118,6 +120,9 @@ func TestGenerate(t *testing.T) {
       ]
     }
   ],
+  "authorities": {
+    "xds.authority.com": {}
+  },
   "node": {
     "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
     "cluster": "cluster",
@@ -131,7 +136,8 @@ func TestGenerate(t *testing.T) {
     "locality": {
       "zone": "uscentral-5"
     }
-  }
+  },
+  "client_default_listener_resource_name_template": "xdstp://xds.authority.com/envoy.config.listener.v3.Listener/%s"
 }`,
 		},
 		{


### PR DESCRIPTION
as per a47 xDS Federation [spec](https://github.com/grpc/proposal/blob/master/A47-xds-federation.md) we need to add the authorities field. 
For the authorities field, we want two entries:

+ Empty string: This will be used for all new style resource names which contain no authority
+ "trafficdirector.googleapis.com:443": This is for new style resource names which explicitly specify TD
For both these entries, we will leave the value empty or {}. That way, they will still both end up talking to TD with the server config specified by the top-level


Note that in `authorities` map authority name's value is empty. This is to force default to the `xds_server_uri` specified in the top level `xds_servers` field. 

Fixes _task 1_ in #32