### PR TITLE
Add support to include c2p authority

### DIFF
--- a/main.go
+++ b/main.go
@@ -383,7 +383,7 @@ func getFromMetadata(urlStr string) ([]byte, error) {
 		return nil, fmt.Errorf("failed reading from metadata server: %w", err)
 	}
 	if code := resp.StatusCode; code < 200 || code > 299 {
-		return nil, fmt.Errorf("failed reading from metadata server with Non-OK status code: %d", code)
+		return nil, fmt.Errorf("metadata server returned status code %d for url %q", code, parsedUrl)
 	}
 	return body, nil
 }

--- a/main.go
+++ b/main.go
@@ -277,7 +277,16 @@ func generate(in configInput) ([]byte, error) {
 			"":    {},
 		}
 		if in.includeC2PAuthority {
-			c.Authorities[c2pAuthority] = Authority{}
+			c.Authorities[c2pAuthority] = Authority{
+				XdsServers: []server{
+					{
+						ServerUri: "dns:///directpath-pa.googleapis.com",
+						ChannelCreds: []creds{
+							{Type: "google_default"},
+						},
+					},
+				},
+			}
 		}
 	}
 
@@ -395,9 +404,11 @@ type server struct {
 	ServerFeatures []string `json:"server_features,omitempty"`
 }
 
-// Authority
-// TODO: add struct implementation when we want to add custom authorities
-type Authority struct{}
+// Authority is the corresponding configuration to an authority name in the map.
+type Authority struct {
+	XdsServers                         []server `json:"xds_servers,omitempty"`
+	ClientListenerResourceNameTemplate string   `json:"client_listener_resource_name_template,omitempty"`
+}
 
 type creds struct {
 	Type   string      `json:"type,omitempty"`

--- a/main_test.go
+++ b/main_test.go
@@ -447,6 +447,62 @@ func TestGenerate(t *testing.T) {
   }
 }`,
 		},
+		{
+			desc: "happy case with v3 defaults and federation support enabled and c2p authority included",
+			input: configInput{
+				xdsServerUri:             "example.com:443",
+				gcpProjectNumber:         123456789012345,
+				vpcNetworkName:           "thedefault",
+				ip:                       "10.9.8.7",
+				zone:                     "uscentral-5",
+				includeV3Features:        true,
+				includeFederationSupport: true,
+				includeC2PAuthority:      true,
+			},
+			wantOutput: `{
+  "xds_servers": [
+    {
+      "server_uri": "example.com:443",
+      "channel_creds": [
+        {
+          "type": "google_default"
+        }
+      ],
+      "server_features": [
+        "xds_v3"
+      ]
+    }
+  ],
+  "authorities": {
+    "": {},
+    "traffic-director-c2p.xds.googleapis.com": {
+      "xds_servers": [
+        {
+          "server_uri": "dns:///directpath-pa.googleapis.com",
+          "channel_creds": [
+            {
+              "type": "google_default"
+            }
+          ]
+        }
+      ]
+    },
+    "trafficdirector.googleapis.com:443": {}
+  },
+  "node": {
+    "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
+    "cluster": "cluster",
+    "metadata": {
+      "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
+      "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
+    },
+    "locality": {
+      "zone": "uscentral-5"
+    }
+  }
+}`,
+		},
 	}
 
 	for _, test := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -450,14 +450,14 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "happy case with v3 defaults and federation support enabled and c2p authority included",
 			input: configInput{
-				xdsServerUri:             "example.com:443",
-				gcpProjectNumber:         123456789012345,
-				vpcNetworkName:           "thedefault",
-				ip:                       "10.9.8.7",
-				zone:                     "uscentral-5",
-				includeV3Features:        true,
-				includeFederationSupport: true,
-				includeC2PAuthority:      true,
+				xdsServerUri:               "example.com:443",
+				gcpProjectNumber:           123456789012345,
+				vpcNetworkName:             "thedefault",
+				ip:                         "10.9.8.7",
+				zone:                       "uscentral-5",
+				includeV3Features:          true,
+				includeFederationSupport:   true,
+				includeDirectPathAuthority: true,
 			},
 			wantOutput: `{
   "xds_servers": [
@@ -483,6 +483,9 @@ func TestGenerate(t *testing.T) {
             {
               "type": "google_default"
             }
+          ],
+          "server_features": [
+            "xds_v3"
           ]
         }
       ]

--- a/main_test.go
+++ b/main_test.go
@@ -631,13 +631,14 @@ func TestCheckIPv6Capable(t *testing.T) {
 			wantOutput: false,
 		},
 	}
-	server := httptest.NewServer(nil)
-	defer server.Close()
-	overrideHTTP(server)
+
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			http.DefaultServeMux = new(http.ServeMux)
-			http.HandleFunc("metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ipv6s", test.httpHandler)
+			mux := new(http.ServeMux)
+			mux.HandleFunc("metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ipv6s", test.httpHandler)
+			server := httptest.NewServer(mux)
+			defer server.Close()
+			overrideHTTP(server)
 			if got := isIPv6Capable(); got != test.wantOutput {
 				t.Fatalf("isIPv6Capable() = %t, want: %t", got, test.wantOutput)
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -634,7 +634,7 @@ func TestCheckIPv6Capable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			mux := new(http.ServeMux)
+			mux := http.NewServeMux()
 			mux.HandleFunc("metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ipv6s", test.httpHandler)
 			server := httptest.NewServer(mux)
 			defer server.Close()

--- a/main_test.go
+++ b/main_test.go
@@ -612,7 +612,7 @@ func TestCheckIPv6Capable(t *testing.T) {
 		wantOutput  bool
 	}{
 		{
-			desc: "case with check on ipv6 enabled host",
+			desc: "v6 enabled",
 			httpHandler: func(w http.ResponseWriter, r *http.Request) {
 				if r.Header.Get("Metadata-Flavor") != "Google" {
 					http.Error(w, "Missing Metadata-Flavor", 403)
@@ -623,7 +623,7 @@ func TestCheckIPv6Capable(t *testing.T) {
 			wantOutput: true,
 		},
 		{
-			desc: "case with check on non ipv6 host",
+			desc: "v6 not enabled",
 			httpHandler: func(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "Not Found", 404)
 				return
@@ -636,13 +636,12 @@ func TestCheckIPv6Capable(t *testing.T) {
 	overrideHTTP(server)
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			uuid.SetRand(rand.New(rand.NewSource(1)))
 			http.DefaultServeMux = new(http.ServeMux)
-			http.HandleFunc("http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ipv6s", test.httpHandler)
-			want := true
-			if got := isIPv6Capable(); got != want {
-				t.Fatalf("isIPv6Capable() = %t, want: %t", got, want)
+			http.HandleFunc("metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ipv6s", test.httpHandler)
+			if got := isIPv6Capable(); got != test.wantOutput {
+				t.Fatalf("isIPv6Capable() = %t, want: %t", got, test.wantOutput)
 			}
+
 		})
 	}
 


### PR DESCRIPTION
As part of xds federation changes, we need to add support to the bootstrap generator to add c2p authority to the config. This change addresses that. 


### what's happenin?
1. add C2P TD authority option using a `include-directpath-authority-experimental` flag 
2. add additional logic to the bootstrap generator to query `http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ipv6s` and set the `TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE` to true or false, in node metadata

Part of #32 
