### PR TITLE
Add flag to use xdstp name for client listener resource template name

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,13 +33,12 @@ import (
 )
 
 const (
-	tdURI        = "trafficdirector.googleapis.com:443"
 	tdAuthority  = "traffic-director-global.xds.googleapis.com"
 	c2pAuthority = "traffic-director-c2p.xds.googleapis.com"
 )
 
 var (
-	xdsServerUri               = flag.String("xds-server-uri", tdURI, "override of server uri, for testing")
+	xdsServerUri               = flag.String("xds-server-uri", tdAuthority, "override of server uri, for testing")
 	outputName                 = flag.String("output", "-", "output file name")
 	gcpProjectNumber           = flag.Int64("gcp-project-number", 0, "the gcp project number. If unknown, can be found via 'gcloud projects list'")
 	vpcNetworkName             = flag.String("vpc-network-name", "default", "VPC network name")
@@ -270,13 +269,13 @@ func generate(in configInput) ([]byte, error) {
 		// the top-level server config. For more details, see:
 		// https://github.com/grpc/proposal/blob/master/A47-xds-federation.md#bootstrap-config-changes.
 		c.Authorities = map[string]Authority{
-			tdURI: {},
-			"":    {},
+			tdAuthority: {},
+			"":          {},
 		}
 		if in.includeXDSTPNameInLDS {
-			if a, ok := c.Authorities[tdURI]; ok {
+			if a, ok := c.Authorities[tdAuthority]; ok {
 				a.ClientListenerResourceNameTemplate = fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", tdAuthority)
-				c.Authorities[tdURI] = a
+				c.Authorities[tdAuthority] = a
 			}
 		}
 		if in.includeDirectPathAuthority {

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ var (
 	includeFederationSupport   = flag.Bool("include-federation-support-experimental", false, "whether or not to generate configs required for xDS Federation. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	includeDirectPathAuthority = flag.Bool("include-directpath-authority-experimental", false, "whether or not to include DirectPath TD authority for xDS Federation. Ignored if not used with include-federation-support-experimental flag. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	// TODO: default to true when TD supports xdstp style names.
-	includeXDSTPNameInLDS = flag.Bool("include-xdstp-name-in-lds-experimental", false, "whether or not to use XDSTP name for . Ignored if not used with both include-federation-support-experimental and include-directpath-authority-experimental flag. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	includeXDSTPNameInLDS = flag.Bool("include-xdstp-name-in-lds-experimental", false, "whether or not to use XDSTP style name for listener resource name template. Ignored if not used with both include-federation-support-experimental and include-directpath-authority-experimental flag. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 )
 
 func main() {
@@ -144,6 +144,7 @@ func main() {
 		includeFederationSupport:   *includeFederationSupport,
 		includeDirectPathAuthority: *includeDirectPathAuthority,
 		ipv6Capable:                isIPv6Capable(),
+		includeXDSTPNameInLDS:      *includeXDSTPNameInLDS,
 	}
 
 	if err := validate(input); err != nil {

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ var (
 	includeFederationSupport   = flag.Bool("include-federation-support-experimental", false, "whether or not to generate configs required for xDS Federation. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	includeDirectPathAuthority = flag.Bool("include-directpath-authority-experimental", false, "whether or not to include DirectPath TD authority for xDS Federation. Ignored if not used with include-federation-support-experimental flag. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	// TODO: default to true when TD supports xdstp style names.
-	includeXDSTPNameInLDS = flag.Bool("include-xdstp-name-in-lds-experimental", false, "whether or not to use XDSTP style name for listener resource name template. Ignored if not used with both include-federation-support-experimental flag. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	includeXDSTPNameInLDS = flag.Bool("include-xdstp-name-in-lds-experimental", false, "whether or not to use XDSTP style name for listener resource name template. Ignored if not used with include-federation-support-experimental flag. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -277,8 +277,7 @@ func generate(in configInput) ([]byte, error) {
 				XdsServers: generateServerConfigsFromInputs("dns:///directpath-pa.googleapis.com", in),
 			}
 			if in.includeXDSTPNameInLDS {
-				template := fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", c2pAuthority)
-				authority.ClientListenerResourceNameTemplate = template
+				authority.ClientListenerResourceNameTemplate = fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", c2pAuthority)
 			}
 			c.Authorities[c2pAuthority] = authority
 			if in.ipv6Capable {

--- a/main.go
+++ b/main.go
@@ -277,8 +277,6 @@ func generate(in configInput) ([]byte, error) {
 			c.Authorities[tdAuthority] = Authority{
 				ClientListenerResourceNameTemplate: fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", tdAuthority),
 			}
-		} else {
-			c.Authorities[tdURI] = Authority{}
 		}
 
 		if in.includeDirectPathAuthority {

--- a/main.go
+++ b/main.go
@@ -270,13 +270,13 @@ func generate(in configInput) ([]byte, error) {
 		// the top-level server config. For more details, see:
 		// https://github.com/grpc/proposal/blob/master/A47-xds-federation.md#bootstrap-config-changes.
 		c.Authorities = map[string]Authority{
-			tdAuthority: {},
-			"":          {},
+			tdURI: {},
+			"":    {},
 		}
 		if in.includeXDSTPNameInLDS {
-			if a, ok := c.Authorities[tdAuthority]; ok {
+			if a, ok := c.Authorities[tdURI]; ok {
 				a.ClientListenerResourceNameTemplate = fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", tdAuthority)
-				c.Authorities[tdAuthority] = a
+				c.Authorities[tdURI] = a
 			}
 		}
 		if in.includeDirectPathAuthority {

--- a/main.go
+++ b/main.go
@@ -270,15 +270,17 @@ func generate(in configInput) ([]byte, error) {
 		// the top-level server config. For more details, see:
 		// https://github.com/grpc/proposal/blob/master/A47-xds-federation.md#bootstrap-config-changes.
 		c.Authorities = map[string]Authority{
-			tdURI: {},
-			"":    {},
+			"": {},
 		}
+
 		if in.includeXDSTPNameInLDS {
-			if a, ok := c.Authorities[tdURI]; ok {
-				a.ClientListenerResourceNameTemplate = fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", tdAuthority)
-				c.Authorities[tdURI] = a
+			c.Authorities[tdAuthority] = Authority{
+				ClientListenerResourceNameTemplate: fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", tdAuthority),
 			}
+		} else {
+			c.Authorities[tdURI] = Authority{}
 		}
+
 		if in.includeDirectPathAuthority {
 			c.Authorities[c2pAuthority] = Authority{
 				XdsServers:                         generateServerConfigsFromInputs("dns:///directpath-pa.googleapis.com", in),

--- a/main.go
+++ b/main.go
@@ -274,7 +274,10 @@ func generate(in configInput) ([]byte, error) {
 			"":    {},
 		}
 		if in.includeXDSTPNameInLDS {
-			c.ClientListenerResourceNameTemplate = fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", tdAuthority)
+			if a, ok := c.Authorities[tdURI]; ok {
+				a.ClientListenerResourceNameTemplate = fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", tdAuthority)
+				c.Authorities[tdURI] = a
+			}
 		}
 		if in.includeDirectPathAuthority {
 			c.Authorities[c2pAuthority] = Authority{
@@ -402,7 +405,6 @@ type config struct {
 	Node                               *node                                `json:"node,omitempty"`
 	CertificateProviders               map[string]certificateProviderConfig `json:"certificate_providers,omitempty"`
 	ServerListenerResourceNameTemplate string                               `json:"server_listener_resource_name_template,omitempty"`
-	ClientListenerResourceNameTemplate string                               `json:"client_listener_resource_name_template,omitempty"`
 }
 
 type server struct {
@@ -433,7 +435,8 @@ func generateServerConfigsFromInputs(serverUri string, in configInput) []server 
 // For more details, see:
 // https://github.com/grpc/proposal/blob/master/A47-xds-federation.md#bootstrap-config-changes
 type Authority struct {
-	XdsServers []server `json:"xds_servers,omitempty"`
+	XdsServers                         []server `json:"xds_servers,omitempty"`
+	ClientListenerResourceNameTemplate string   `json:"client_listener_resource_name_template,omitempty"`
 }
 
 type creds struct {

--- a/main.go
+++ b/main.go
@@ -33,12 +33,13 @@ import (
 )
 
 const (
+	tdURI        = "trafficdirector.googleapis.com:443"
 	tdAuthority  = "traffic-director-global.xds.googleapis.com"
 	c2pAuthority = "traffic-director-c2p.xds.googleapis.com"
 )
 
 var (
-	xdsServerUri               = flag.String("xds-server-uri", tdAuthority, "override of server uri, for testing")
+	xdsServerUri               = flag.String("xds-server-uri", tdURI, "override of server uri, for testing")
 	outputName                 = flag.String("output", "-", "output file name")
 	gcpProjectNumber           = flag.Int64("gcp-project-number", 0, "the gcp project number. If unknown, can be found via 'gcloud projects list'")
 	vpcNetworkName             = flag.String("vpc-network-name", "default", "VPC network name")

--- a/main.go
+++ b/main.go
@@ -277,10 +277,9 @@ func generate(in configInput) ([]byte, error) {
 			c.ClientListenerResourceNameTemplate = fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", tdAuthority)
 		}
 		if in.includeDirectPathAuthority {
-			authority := Authority{
+			c.Authorities[c2pAuthority] = Authority{
 				XdsServers: generateServerConfigsFromInputs("dns:///directpath-pa.googleapis.com", in),
 			}
-			c.Authorities[c2pAuthority] = authority
 			if in.ipv6Capable {
 				c.Node.Metadata["TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE"] = true
 			}

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ import (
 
 const (
 	tdURI        = "trafficdirector.googleapis.com:443"
+	tdAuthority  = "traffic-director-global.xds.googleapis.com"
 	c2pAuthority = "traffic-director-c2p.xds.googleapis.com"
 )
 
@@ -277,7 +278,7 @@ func generate(in configInput) ([]byte, error) {
 				XdsServers: generateServerConfigsFromInputs("dns:///directpath-pa.googleapis.com", in),
 			}
 			if in.includeXDSTPNameInLDS {
-				authority.ClientListenerResourceNameTemplate = fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", c2pAuthority)
+				authority.ClientListenerResourceNameTemplate = fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", tdAuthority)
 			}
 			c.Authorities[c2pAuthority] = authority
 			if in.ipv6Capable {

--- a/main_test.go
+++ b/main_test.go
@@ -509,7 +509,7 @@ func TestGenerate(t *testing.T) {
 }`,
 		},
 		{
-			desc: "happy case with federation support, c2p authority, and xdstp name included",
+			desc: "happy case with federation support, c2p authority, and xdstp name flag included",
 			input: configInput{
 				xdsServerUri:               "example.com:443",
 				gcpProjectNumber:           123456789012345,
@@ -553,7 +553,9 @@ func TestGenerate(t *testing.T) {
         }
       ]
     },
-    "trafficdirector.googleapis.com:443": {}
+    "trafficdirector.googleapis.com:443": {
+      "client_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
+    }
   },
   "node": {
     "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
@@ -567,8 +569,7 @@ func TestGenerate(t *testing.T) {
     "locality": {
       "zone": "uscentral-5"
     }
-  },
-  "client_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
+  }
 }`,
 		},
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -431,7 +431,7 @@ func TestGenerate(t *testing.T) {
   ],
   "authorities": {
     "": {},
-    "trafficdirector.googleapis.com:443": {}
+    "traffic-director-global.xds.googleapis.com": {}
   },
   "node": {
     "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
@@ -552,7 +552,8 @@ func TestGenerate(t *testing.T) {
             "xds_v3"
           ]
         }
-      ]
+      ],
+      "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
     },
     "traffic-director-global.xds.googleapis.com": {
       "client_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"

--- a/main_test.go
+++ b/main_test.go
@@ -431,7 +431,7 @@ func TestGenerate(t *testing.T) {
   ],
   "authorities": {
     "": {},
-    "traffic-director-global.xds.googleapis.com": {}
+    "trafficdirector.googleapis.com:443": {}
   },
   "node": {
     "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
@@ -492,7 +492,7 @@ func TestGenerate(t *testing.T) {
       ],
       "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
     },
-    "traffic-director-global.xds.googleapis.com": {}
+    "trafficdirector.googleapis.com:443": {}
   },
   "node": {
     "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
@@ -512,7 +512,7 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "happy case with federation support in directpath with new xdstp style name",
 			input: configInput{
-				xdsServerUri:               "traffic-director-global.xds.googleapis.com",
+				xdsServerUri:               "trafficdirector.googleapis.com:443",
 				gcpProjectNumber:           123456789012345,
 				vpcNetworkName:             "thedefault",
 				ip:                         "10.9.8.7",
@@ -526,7 +526,7 @@ func TestGenerate(t *testing.T) {
 			wantOutput: `{
   "xds_servers": [
     {
-      "server_uri": "traffic-director-global.xds.googleapis.com",
+      "server_uri": "trafficdirector.googleapis.com:443",
       "channel_creds": [
         {
           "type": "google_default"
@@ -555,7 +555,7 @@ func TestGenerate(t *testing.T) {
       ],
       "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
     },
-    "traffic-director-global.xds.googleapis.com": {
+    "trafficdirector.googleapis.com:443": {
       "client_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
     }
   },

--- a/main_test.go
+++ b/main_test.go
@@ -508,6 +508,69 @@ func TestGenerate(t *testing.T) {
   }
 }`,
 		},
+		{
+			desc: "happy case with federation support, c2p authority, and xdstp name included",
+			input: configInput{
+				xdsServerUri:               "example.com:443",
+				gcpProjectNumber:           123456789012345,
+				vpcNetworkName:             "thedefault",
+				ip:                         "10.9.8.7",
+				zone:                       "uscentral-5",
+				includeV3Features:          true,
+				includeFederationSupport:   true,
+				includeDirectPathAuthority: true,
+				ipv6Capable:                true,
+				includeXDSTPNameInLDS:      true,
+			},
+			wantOutput: `{
+  "xds_servers": [
+    {
+      "server_uri": "example.com:443",
+      "channel_creds": [
+        {
+          "type": "google_default"
+        }
+      ],
+      "server_features": [
+        "xds_v3"
+      ]
+    }
+  ],
+  "authorities": {
+    "": {},
+    "traffic-director-c2p.xds.googleapis.com": {
+      "xds_servers": [
+        {
+          "server_uri": "dns:///directpath-pa.googleapis.com",
+          "channel_creds": [
+            {
+              "type": "google_default"
+            }
+          ],
+          "server_features": [
+            "xds_v3"
+          ]
+        }
+      ],
+      "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
+    },
+    "trafficdirector.googleapis.com:443": {}
+  },
+  "node": {
+    "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
+    "cluster": "cluster",
+    "metadata": {
+      "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true,
+      "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
+      "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
+    },
+    "locality": {
+      "zone": "uscentral-5"
+    }
+  }
+}`,
+		},
 	}
 
 	for _, test := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -450,7 +450,7 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "happy case federation support enabled and c2p authority included",
 			input: configInput{
-				xdsServerUri:               "traffic-director-global.xds.googleapis.com",
+				xdsServerUri:               "example.com:443",
 				gcpProjectNumber:           123456789012345,
 				vpcNetworkName:             "thedefault",
 				ip:                         "10.9.8.7",
@@ -463,7 +463,7 @@ func TestGenerate(t *testing.T) {
 			wantOutput: `{
   "xds_servers": [
     {
-      "server_uri": "traffic-director-global.xds.googleapis.com",
+      "server_uri": "example.com:443",
       "channel_creds": [
         {
           "type": "google_default"

--- a/main_test.go
+++ b/main_test.go
@@ -448,9 +448,9 @@ func TestGenerate(t *testing.T) {
 }`,
 		},
 		{
-			desc: "happy case with v3 defaults and federation support enabled and c2p authority included",
+			desc: "happy case federation support enabled and c2p authority included",
 			input: configInput{
-				xdsServerUri:               "example.com:443",
+				xdsServerUri:               "traffic-director-global.xds.googleapis.com",
 				gcpProjectNumber:           123456789012345,
 				vpcNetworkName:             "thedefault",
 				ip:                         "10.9.8.7",
@@ -463,7 +463,7 @@ func TestGenerate(t *testing.T) {
 			wantOutput: `{
   "xds_servers": [
     {
-      "server_uri": "example.com:443",
+      "server_uri": "traffic-director-global.xds.googleapis.com",
       "channel_creds": [
         {
           "type": "google_default"
@@ -491,7 +491,7 @@ func TestGenerate(t *testing.T) {
         }
       ]
     },
-    "trafficdirector.googleapis.com:443": {}
+    "traffic-director-global.xds.googleapis.com": {}
   },
   "node": {
     "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
@@ -509,9 +509,9 @@ func TestGenerate(t *testing.T) {
 }`,
 		},
 		{
-			desc: "happy case with federation support, c2p authority, and xdstp name flag included",
+			desc: "happy case with federation support in directpath with new xdstp style name",
 			input: configInput{
-				xdsServerUri:               "example.com:443",
+				xdsServerUri:               "traffic-director-global.xds.googleapis.com",
 				gcpProjectNumber:           123456789012345,
 				vpcNetworkName:             "thedefault",
 				ip:                         "10.9.8.7",
@@ -525,7 +525,7 @@ func TestGenerate(t *testing.T) {
 			wantOutput: `{
   "xds_servers": [
     {
-      "server_uri": "example.com:443",
+      "server_uri": "traffic-director-global.xds.googleapis.com",
       "channel_creds": [
         {
           "type": "google_default"
@@ -553,7 +553,7 @@ func TestGenerate(t *testing.T) {
         }
       ]
     },
-    "trafficdirector.googleapis.com:443": {
+    "traffic-director-global.xds.googleapis.com": {
       "client_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
     }
   },

--- a/main_test.go
+++ b/main_test.go
@@ -448,7 +448,7 @@ func TestGenerate(t *testing.T) {
 }`,
 		},
 		{
-			desc: "happy case federation support enabled and c2p authority included",
+			desc: "happy case with federation support enabled and c2p authority included",
 			input: configInput{
 				xdsServerUri:               "example.com:443",
 				gcpProjectNumber:           123456789012345,
@@ -555,7 +555,7 @@ func TestGenerate(t *testing.T) {
       ],
       "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
     },
-    "trafficdirector.googleapis.com:443": {
+    "traffic-director-global.xds.googleapis.com": {
       "client_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
     }
   },

--- a/main_test.go
+++ b/main_test.go
@@ -551,8 +551,7 @@ func TestGenerate(t *testing.T) {
             "xds_v3"
           ]
         }
-      ],
-      "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
+      ]
     },
     "trafficdirector.googleapis.com:443": {}
   },
@@ -568,7 +567,8 @@ func TestGenerate(t *testing.T) {
     "locality": {
       "zone": "uscentral-5"
     }
-  }
+  },
+  "client_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
 }`,
 		},
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -430,8 +430,7 @@ func TestGenerate(t *testing.T) {
     }
   ],
   "authorities": {
-    "": {},
-    "trafficdirector.googleapis.com:443": {}
+    "": {}
   },
   "node": {
     "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
@@ -491,8 +490,7 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
-    },
-    "trafficdirector.googleapis.com:443": {}
+    }
   },
   "node": {
     "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",


### PR DESCRIPTION
We added the `client_default_listener_resource_name_template` field to the bootstrap config as per  [A47](https://github.com/grpc/proposal/blob/master/A47-xds-federation.md). 

We would like to have the option for the bootstrap generator to add field to the authorities with the xdstp style name for listener resources with TD c2p authority name (when used in conjunction with `includeFederationSupport` and `includeDirectPathAuthority` flags. 

This PR adds a flag to support this. 

##### Other fix:
+ `trafficdirector.googleapis.com:443` seems wrong and should be `traffic-director-global.xds.googleapis.com` instead
  + When we do a lookup for which server to request for a CDS resource, it seems we wouldn't find a control plane
