### PR TITLE
Use xdstp name for client listener resource template name for C2P

### DIFF
--- a/main.go
+++ b/main.go
@@ -270,7 +270,8 @@ func generate(in configInput) ([]byte, error) {
 		}
 		if in.includeDirectPathAuthority {
 			c.Authorities[c2pAuthority] = Authority{
-				XdsServers: generateServerConfigsFromInputs("dns:///directpath-pa.googleapis.com", in),
+				XdsServers:                         generateServerConfigsFromInputs("dns:///directpath-pa.googleapis.com", in),
+				ClientListenerResourceNameTemplate: fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", c2pAuthority),
 			}
 			if in.ipv6Capable {
 				c.Node.Metadata["TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE"] = true
@@ -424,7 +425,8 @@ func generateServerConfigsFromInputs(serverUri string, in configInput) []server 
 // For more details, see:
 // https://github.com/grpc/proposal/blob/master/A47-xds-federation.md#bootstrap-config-changes
 type Authority struct {
-	XdsServers []server `json:"xds_servers,omitempty"`
+	XdsServers                         []server `json:"xds_servers,omitempty"`
+	ClientListenerResourceNameTemplate string   `json:"client_listener_resource_name_template,omitempty"`
 }
 
 type creds struct {

--- a/main_test.go
+++ b/main_test.go
@@ -489,7 +489,8 @@ func TestGenerate(t *testing.T) {
             "xds_v3"
           ]
         }
-      ]
+      ],
+      "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
     },
     "trafficdirector.googleapis.com:443": {}
   },


### PR DESCRIPTION
As per [A47](https://github.com/grpc/proposal/blob/master/A47-xds-federation.md), a new field called `client_listener_resource_template` has been added to the `authorities` field. 

In a C2P directPath use case we want the `C2PAuthority` to include a `client_listener_resource_template` with the new xdstp style name. The Url to be used has been referenced from [here](https://docs.google.com/document/d/1xwuSTdtV4I8MXXO_A0TIGAYtysbkothSBoH5xVuyr5I/edit#heading=h.ykp0ozda8boq). 

Also modifying existing unit test.