### PR TITLE
ignore_resource_deletion server feature is always set in directpath use-cases

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -485,7 +485,8 @@ func TestGenerate(t *testing.T) {
             }
           ],
           "server_features": [
-            "xds_v3"
+            "xds_v3",
+            "ignore_resource_deletion"
           ]
         }
       ],
@@ -547,7 +548,8 @@ func TestGenerate(t *testing.T) {
             }
           ],
           "server_features": [
-            "xds_v3"
+            "xds_v3",
+            "ignore_resource_deletion"
           ]
         }
       ],


### PR DESCRIPTION
Now in DIrectpath (C2P) usecases, `ignore_resource_deletion` server feature can always be set.