### PR TITLE
Fix LDS resource name format for TD authority

### DIFF
--- a/main.go
+++ b/main.go
@@ -280,7 +280,7 @@ func generate(in configInput) ([]byte, error) {
 		if in.includeXDSTPNameInLDS {
 			tdAuthority := "traffic-director-global.xds.googleapis.com"
 			c.Authorities[tdAuthority] = Authority{
-				// Listener Resource Name format for p2c config looks like:
+				// Listener Resource Name format for normal TD usecases looks like:
 				// xdstp://<authority>/envoy.config.listener.v3.Listener/<project_number>/<(network)|(mesh:mesh_name)>/id
 				ClientListenerResourceNameTemplate: fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%d/%s/%%s", tdAuthority, in.gcpProjectNumber, networkIdentifier),
 			}

--- a/main.go
+++ b/main.go
@@ -236,15 +236,15 @@ func generate(in configInput) ([]byte, error) {
 	for k, v := range in.metadataLabels {
 		c.Node.Metadata[k] = v
 	}
+
+	networkIdentifier := in.vpcNetworkName
+	if in.configMesh != "" {
+		networkIdentifier = fmt.Sprintf("mesh:%s", in.configMesh)
+	}
 	if in.includeV3Features {
 		// xDS v2 implementation in TD expects the projectNumber and networkName in
 		// the metadata field while the v3 implementation expects these in the id
 		// field.
-		networkIdentifier := in.vpcNetworkName
-		if in.configMesh != "" {
-			networkIdentifier = fmt.Sprintf("mesh:%s", in.configMesh)
-		}
-
 		c.Node.Id = fmt.Sprintf("projects/%d/networks/%s/nodes/%s", in.gcpProjectNumber, networkIdentifier, uuid.New().String())
 		// xDS v2 implementation in TD expects the IP address to be encoded in the
 		// id field while the v3 implementation expects this in the metadata.
@@ -280,7 +280,9 @@ func generate(in configInput) ([]byte, error) {
 		if in.includeXDSTPNameInLDS {
 			tdAuthority := "traffic-director-global.xds.googleapis.com"
 			c.Authorities[tdAuthority] = Authority{
-				ClientListenerResourceNameTemplate: fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", tdAuthority),
+				// Listener Resource Name format for p2c config looks like:
+				// xdstp://<authority>/envoy.config.listener.v3.Listener/<project_number>/<(network)|(mesh:mesh_name)>/id
+				ClientListenerResourceNameTemplate: fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%d/%s/%%s", tdAuthority, in.gcpProjectNumber, networkIdentifier),
 			}
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -556,7 +556,7 @@ func TestGenerate(t *testing.T) {
       "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
     },
     "traffic-director-global.xds.googleapis.com": {
-      "client_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
+      "client_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/123456789012345/thedefault/%s"
     }
   },
   "node": {


### PR DESCRIPTION
The LDS resource name format was incorrect. The correct format as per the xDS TD documentation is 

```
xdstp://<authority>/envoy.config.listener.v3.Listener/<project_number>/<(network)|(mesh:mesh_name)>/id
```

This change fixes the format. 