### PR TITLE
Add unit test to test default behavior

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -635,7 +635,7 @@ func TestGenerate(t *testing.T) {
       "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
     },
     "traffic-director-global.xds.googleapis.com": {
-      "client_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/123456789012345/thedefault/%s"
+      "client_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
     }
   },
   "node": {

--- a/main_test.go
+++ b/main_test.go
@@ -148,7 +148,6 @@ func TestDefault(t *testing.T) {
 		configMesh:                 *configMesh,
 		includeFederationSupport:   *includeFederationSupport,
 		includeDirectPathAuthority: *includeDirectPathAuthority,
-		ipv6Capable:                isIPv6Capable(),
 		includeXDSTPNameInLDS:      *includeXDSTPNameInLDS,
 	}
 	// Make UUID.New().String() deterministic.


### PR DESCRIPTION
Flags are knobs that control the output generated by this generator. The flags also have a default value. Currently we (try to) have unit tests around each scenario the bootstrap generator could be likely used for. However we do not have a test case around what the config that is outputted when there are no flag values being passed. 

I tried to see if there was a clean way of testing main(), however since the output is either written to stdout or to a file and since there are APIs calls being made (like for eg to the metadata server), This approach uses `flag.Parse()` to get the args into variables. However with this approach we are forcing a mechanism to update this test whenever there is an update the flags.  