### PR TITLE
remove empty string authority from authorities map

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,10 +48,9 @@ var (
 	gkeNamespace               = flag.String("gke-namespace-experimental", "", "GKE namespace to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	gceVM                      = flag.String("gce-vm-experimental", "", "GCE VM name to use, instead of reading it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	configMesh                 = flag.String("config-mesh-experimental", "", "Dictates which Mesh resource to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	includeFederationSupport   = flag.Bool("include-federation-support-experimental", true, "whether or not to generate configs required for xDS Federation. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	includeDirectPathAuthority = flag.Bool("include-directpath-authority-experimental", false, "whether or not to include DirectPath TD authority for xDS Federation. Ignored if not used with include-federation-support-experimental flag. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	includeDirectPathAuthority = flag.Bool("include-directpath-authority-experimental", false, "whether or not to include DirectPath TD authority for xDS Federation. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	// TODO: default to true when TD supports xdstp style names.
-	includeXDSTPNameInLDS = flag.Bool("include-xdstp-name-in-lds-experimental", false, "whether or not to use XDSTP style name for listener resource name template. Ignored if not used with include-federation-support-experimental flag. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	includeXDSTPNameInLDS = flag.Bool("include-xdstp-name-in-lds-experimental", false, "whether or not to use XDSTP style name for listener resource name template. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 )
 
 func main() {
@@ -136,7 +135,6 @@ func main() {
 		metadataLabels:             nodeMetadata,
 		deploymentInfo:             deploymentInfo,
 		configMesh:                 *configMesh,
-		includeFederationSupport:   *includeFederationSupport,
 		includeDirectPathAuthority: *includeDirectPathAuthority,
 		ipv6Capable:                isIPv6Capable(),
 		includeXDSTPNameInLDS:      *includeXDSTPNameInLDS,
@@ -192,7 +190,6 @@ type configInput struct {
 	metadataLabels             map[string]string
 	deploymentInfo             map[string]string
 	configMesh                 string
-	includeFederationSupport   bool
 	includeDirectPathAuthority bool
 	ipv6Capable                bool
 	includeXDSTPNameInLDS      bool
@@ -269,38 +266,36 @@ func generate(in configInput) ([]byte, error) {
 	if in.deploymentInfo != nil {
 		c.Node.Metadata["TRAFFIC_DIRECTOR_CLIENT_ENVIRONMENT"] = in.deploymentInfo
 	}
-	if in.includeFederationSupport {
-		// Authorities with an empty server config will end up using
-		// the top-level server config. For more details, see:
-		// https://github.com/grpc/proposal/blob/master/A47-xds-federation.md#bootstrap-config-changes.
-		c.Authorities = map[string]Authority{
-			"": {},
-		}
 
-		if in.includeXDSTPNameInLDS {
-			tdAuthority := "traffic-director-global.xds.googleapis.com"
-			c.Authorities[tdAuthority] = Authority{
-				// Listener Resource Name format for normal TD usecases looks like:
-				// xdstp://<authority>/envoy.config.listener.v3.Listener/<project_number>/<(network)|(mesh:mesh_name)>/id
-				ClientListenerResourceNameTemplate: fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%d/%s/%%s", tdAuthority, in.gcpProjectNumber, networkIdentifier),
-			}
+	if in.includeXDSTPNameInLDS {
+		if c.Authorities == nil {
+			c.Authorities = make(map[string]Authority)
 		}
+		tdAuthority := "traffic-director-global.xds.googleapis.com"
+		c.Authorities[tdAuthority] = Authority{
+			// Listener Resource Name format for normal TD usecases looks like:
+			// xdstp://<authority>/envoy.config.listener.v3.Listener/<project_number>/<(network)|(mesh:mesh_name)>/id
+			ClientListenerResourceNameTemplate: fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%d/%s/%%s", tdAuthority, in.gcpProjectNumber, networkIdentifier),
+		}
+	}
 
-		if in.includeDirectPathAuthority {
-			c2pAuthority := "traffic-director-c2p.xds.googleapis.com"
-			c.Authorities[c2pAuthority] = Authority{
-				// In the case of DirectPath, it is safe to assume that the operator is notified of missing resources.
-				// In other words, "ignore_resource_deletion" server_features is always set.
-				XdsServers: []server{{
-					ServerUri:      "dns:///directpath-pa.googleapis.com",
-					ChannelCreds:   []creds{{Type: "google_default"}},
-					ServerFeatures: []string{"xds_v3", "ignore_resource_deletion"},
-				}},
-				ClientListenerResourceNameTemplate: fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", c2pAuthority),
-			}
-			if in.ipv6Capable {
-				c.Node.Metadata["TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE"] = true
-			}
+	if in.includeDirectPathAuthority {
+		if c.Authorities == nil {
+			c.Authorities = make(map[string]Authority)
+		}
+		c2pAuthority := "traffic-director-c2p.xds.googleapis.com"
+		c.Authorities[c2pAuthority] = Authority{
+			// In the case of DirectPath, it is safe to assume that the operator is notified of missing resources.
+			// In other words, "ignore_resource_deletion" server_features is always set.
+			XdsServers: []server{{
+				ServerUri:      "dns:///directpath-pa.googleapis.com",
+				ChannelCreds:   []creds{{Type: "google_default"}},
+				ServerFeatures: []string{"xds_v3", "ignore_resource_deletion"},
+			}},
+			ClientListenerResourceNameTemplate: fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", c2pAuthority),
+		}
+		if in.ipv6Capable {
+			c.Node.Metadata["TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE"] = true
 		}
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -405,49 +405,7 @@ func TestGenerate(t *testing.T) {
 }`,
 		},
 		{
-			desc: "happy case with v3 defaults and federation support enabled",
-			input: configInput{
-				xdsServerUri:             "example.com:443",
-				gcpProjectNumber:         123456789012345,
-				vpcNetworkName:           "thedefault",
-				ip:                       "10.9.8.7",
-				zone:                     "uscentral-5",
-				includeV3Features:        true,
-				includeFederationSupport: true,
-			},
-			wantOutput: `{
-  "xds_servers": [
-    {
-      "server_uri": "example.com:443",
-      "channel_creds": [
-        {
-          "type": "google_default"
-        }
-      ],
-      "server_features": [
-        "xds_v3"
-      ]
-    }
-  ],
-  "authorities": {
-    "": {}
-  },
-  "node": {
-    "id": "projects/123456789012345/networks/thedefault/nodes/9566c74d-1003-4c4d-bbbb-0407d1e2c649",
-    "cluster": "cluster",
-    "metadata": {
-      "INSTANCE_IP": "10.9.8.7",
-      "TRAFFICDIRECTOR_GCP_PROJECT_NUMBER": "123456789012345",
-      "TRAFFICDIRECTOR_NETWORK_NAME": "thedefault"
-    },
-    "locality": {
-      "zone": "uscentral-5"
-    }
-  }
-}`,
-		},
-		{
-			desc: "happy case with federation support enabled and c2p authority included",
+			desc: "happy case with federation support of c2p authority included",
 			input: configInput{
 				xdsServerUri:               "example.com:443",
 				gcpProjectNumber:           123456789012345,
@@ -455,7 +413,6 @@ func TestGenerate(t *testing.T) {
 				ip:                         "10.9.8.7",
 				zone:                       "uscentral-5",
 				includeV3Features:          true,
-				includeFederationSupport:   true,
 				includeDirectPathAuthority: true,
 				ipv6Capable:                true,
 			},
@@ -474,7 +431,6 @@ func TestGenerate(t *testing.T) {
     }
   ],
   "authorities": {
-    "": {},
     "traffic-director-c2p.xds.googleapis.com": {
       "xds_servers": [
         {
@@ -509,7 +465,7 @@ func TestGenerate(t *testing.T) {
 }`,
 		},
 		{
-			desc: "happy case with federation support in directpath with new xdstp style name",
+			desc: "happy case with federation support of c2p along with regular TD using xdstp style name",
 			input: configInput{
 				xdsServerUri:               "trafficdirector.googleapis.com:443",
 				gcpProjectNumber:           123456789012345,
@@ -517,7 +473,6 @@ func TestGenerate(t *testing.T) {
 				ip:                         "10.9.8.7",
 				zone:                       "uscentral-5",
 				includeV3Features:          true,
-				includeFederationSupport:   true,
 				includeDirectPathAuthority: true,
 				ipv6Capable:                true,
 				includeXDSTPNameInLDS:      true,
@@ -537,7 +492,6 @@ func TestGenerate(t *testing.T) {
     }
   ],
   "authorities": {
-    "": {},
     "traffic-director-c2p.xds.googleapis.com": {
       "xds_servers": [
         {


### PR DESCRIPTION
The empty authority is not being used as per [A47](https://github.com/grpc/proposal/blob/master/A47-xds-federation.md). This change removes that and also nixes a flag which would then become unused. 