### PR TITLE
Update cloudbuild-artificats.yaml build step

### DIFF
--- a/tools/cloudbuild-artifacts.yaml
+++ b/tools/cloudbuild-artifacts.yaml
@@ -14,7 +14,7 @@
 
 steps:
 - name: golang:1.18
-  args: ['go', 'build', './...']
+  args: ['go', 'build', '.']
 - name: golang:1.18
   args: ['go', 'test', './...']
 - name: alpine


### PR DESCRIPTION
Since there are 2 packages now we need to use `go build .` to create the binary. `go test` still need to run for all the sub directories