### PR TITLE
replace deprecated ioutil.ReadAll with io.ReadAll

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -373,11 +373,6 @@ func getClusterName() (string, error) {
 	return string(cluster), nil
 }
 
-// For overriding in unit tests.
-var readHostNameFile = func() ([]byte, error) {
-	return ioutil.ReadFile("/etc/hostname")
-}
-
 func getPodName() string {
 	pod, err := os.Hostname()
 	if err != nil {
@@ -421,7 +416,7 @@ func getFromMetadata(urlStr string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed communicating with metadata server: %w", err)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		return nil, fmt.Errorf("failed reading from metadata server: %w", err)


### PR DESCRIPTION
Changes: 
- Remove deprecated usage of [io/ioutil.ReallAll](pkg.go.dev/io/ioutil#ReadAll) with io.ReadAll
- Remove unused helper function 
