### PR TITLE
add generator commit hash to node metadata

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,4 +17,4 @@ jobs:
           go-version: 1.21
 
       - name: Run tests
-        run: go test -v ./...
+        run: go test -v ./... -buildvcs=true

--- a/main.go
+++ b/main.go
@@ -167,7 +167,7 @@ func main() {
 	var gitCommitHash string
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		fmt.Fprintf(os.Stderr, "Error: unable read to the build information embedded in the running binary.")
+		fmt.Fprintln(os.Stderr, "Error: unable read to the build information embedded in the running binary")
 		os.Exit(1)
 	}
 	for _, setting := range info.Settings {

--- a/main.go
+++ b/main.go
@@ -167,7 +167,7 @@ func main() {
 	var gitCommitHash string
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		fmt.Fprintln(os.Stderr, "Error: unable read to the build information embedded in the running binary")
+		fmt.Fprintln(os.Stderr, "Error: unable to determine git commit hash from build information embedded in the running binary")
 		os.Exit(1)
 	}
 	for _, setting := range info.Settings {

--- a/main_test.go
+++ b/main_test.go
@@ -38,42 +38,6 @@ func TestGetGitCommitId(t *testing.T) {
 	if !re.MatchString(commitId) {
 		t.Fatal("getGitCommitId(): returned an invalid commit ID. Want commit ID to be a valid SHA1 hash.")
 	}
-
-	// // Build td-grpc-bootstrap binary.
-	// cmd := exec.Command("go", "build", ".")
-	// if _, err := cmd.Output(); err != nil {
-	// 	t.Fatalf("Error building bootstrap generator: %s", err)
-	// }
-
-	// // We cannot stub the HTTP calls to Metadata server when executing the
-	// // binary this way. Hence passing in arguments so that the generator to exit
-	// // with error. Warnings are ignored. The generated config is unmarshalled to c.
-	// runCmd := exec.Command("./td-grpc-bootstrap", "--gcp-project-number=1233445")
-	// output, err := runCmd.Output()
-	// if err != nil {
-	// 	t.Fatalf("Error running bootstrap generator: %s", err)
-	// }
-	// c := config{}
-	// if err = json.Unmarshal([]byte(output), &c); err != nil {
-	// 	t.Fatalf("Error unmarshalling generated output: %s", err)
-	// }
-	// commitShaUsedInConfig, ok := c.Node.Metadata["TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA"]
-	// if !ok {
-	// 	t.Fatal("Error: Key TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA not found in generated config's Node Metadata")
-	// }
-
-	// // Use git to fetch commit ID of HEAD.
-	// gitCmd := exec.Command("git", "rev-parse", "HEAD")
-	// commitSha, err := gitCmd.Output()
-	// if err != nil {
-	// 	t.Fatalf("Error running git rev-parse: %s", err)
-	// }
-	// // Trim to remove the trailing new line from output.
-	// commitShaFromGit := strings.TrimSpace(string(commitSha))
-
-	// if diff := cmp.Diff(commitShaFromGit, commitShaUsedInConfig.(string)); diff != "" {
-	// 	t.Fatalf("Error: Commit id in boostrap config (%s) does not match the expected ID (-want +got):\n%s", commitShaUsedInConfig, diff)
-	// }
 }
 
 func TestValidate(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -99,6 +99,7 @@ func TestGenerate(t *testing.T) {
 				ip:               "10.9.8.7",
 				zone:             "uscentral-5",
 				metadataLabels:   map[string]string{"k1": "v1", "k2": "v2"},
+				gitCommitHash:    "7202b7c611ebd6d382b7b0240f50e9824200bffd",
 			},
 			wantOutput: `{
   "xds_servers": [
@@ -119,6 +120,7 @@ func TestGenerate(t *testing.T) {
     "cluster": "cluster",
     "metadata": {
       "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "7202b7c611ebd6d382b7b0240f50e9824200bffd",
       "k1": "v1",
       "k2": "v2"
     },
@@ -149,6 +151,7 @@ func TestGenerate(t *testing.T) {
 				ip:               "10.9.8.7",
 				zone:             "uscentral-5",
 				secretsDir:       "/secrets/dir/",
+				gitCommitHash:    "7202b7c611ebd6d382b7b0240f50e9824200bffd",
 			},
 			wantOutput: `{
   "xds_servers": [
@@ -168,7 +171,8 @@ func TestGenerate(t *testing.T) {
     "id": "projects/123456789012345/networks/thedefault/nodes/52fdfc07-2182-454f-963f-5f0f9a621d72",
     "cluster": "cluster",
     "metadata": {
-      "INSTANCE_IP": "10.9.8.7"
+      "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "7202b7c611ebd6d382b7b0240f50e9824200bffd"
     },
     "locality": {
       "zone": "uscentral-5"
@@ -204,6 +208,7 @@ func TestGenerate(t *testing.T) {
 					"INSTANCE-IP":   "10.9.8.7",
 					"GCE-VM":        "test-gce-vm",
 				},
+				gitCommitHash: "7202b7c611ebd6d382b7b0240f50e9824200bffd",
 			},
 			wantOutput: `{
   "xds_servers": [
@@ -224,6 +229,7 @@ func TestGenerate(t *testing.T) {
     "cluster": "cluster",
     "metadata": {
       "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "7202b7c611ebd6d382b7b0240f50e9824200bffd",
       "TRAFFIC_DIRECTOR_CLIENT_ENVIRONMENT": {
         "GCE-VM": "test-gce-vm",
         "GCP-ZONE": "uscentral-5",
@@ -267,7 +273,8 @@ func TestGenerate(t *testing.T) {
 					"INSTANCE-IP":   "10.9.8.7",
 					"GCE-VM":        "test-gce-vm",
 				},
-				configMesh: "testmesh",
+				configMesh:    "testmesh",
+				gitCommitHash: "7202b7c611ebd6d382b7b0240f50e9824200bffd",
 			},
 			wantOutput: `{
   "xds_servers": [
@@ -288,6 +295,7 @@ func TestGenerate(t *testing.T) {
     "cluster": "cluster",
     "metadata": {
       "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "7202b7c611ebd6d382b7b0240f50e9824200bffd",
       "TRAFFIC_DIRECTOR_CLIENT_ENVIRONMENT": {
         "GCE-VM": "test-gce-vm",
         "GCP-ZONE": "uscentral-5",
@@ -324,6 +332,7 @@ func TestGenerate(t *testing.T) {
 				ip:                     "10.9.8.7",
 				zone:                   "uscentral-5",
 				ignoreResourceDeletion: true,
+				gitCommitHash:          "7202b7c611ebd6d382b7b0240f50e9824200bffd",
 			},
 			wantOutput: `{
   "xds_servers": [
@@ -344,7 +353,8 @@ func TestGenerate(t *testing.T) {
     "id": "projects/123456789012345/networks/thedefault/nodes/52fdfc07-2182-454f-963f-5f0f9a621d72",
     "cluster": "cluster",
     "metadata": {
-      "INSTANCE_IP": "10.9.8.7"
+      "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "7202b7c611ebd6d382b7b0240f50e9824200bffd"
     },
     "locality": {
       "zone": "uscentral-5"
@@ -374,6 +384,7 @@ func TestGenerate(t *testing.T) {
 				zone:                       "uscentral-5",
 				includeDirectPathAuthority: true,
 				ipv6Capable:                true,
+				gitCommitHash:              "7202b7c611ebd6d382b7b0240f50e9824200bffd",
 			},
 			wantOutput: `{
   "xds_servers": [
@@ -413,7 +424,8 @@ func TestGenerate(t *testing.T) {
     "cluster": "cluster",
     "metadata": {
       "INSTANCE_IP": "10.9.8.7",
-      "TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
+      "TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true,
+      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "7202b7c611ebd6d382b7b0240f50e9824200bffd"
     },
     "locality": {
       "zone": "uscentral-5"
@@ -444,6 +456,7 @@ func TestGenerate(t *testing.T) {
 				includeDirectPathAuthority: true,
 				ipv6Capable:                true,
 				includeXDSTPNameInLDS:      true,
+				gitCommitHash:              "7202b7c611ebd6d382b7b0240f50e9824200bffd",
 			},
 			wantOutput: `{
   "xds_servers": [
@@ -486,7 +499,8 @@ func TestGenerate(t *testing.T) {
     "cluster": "cluster",
     "metadata": {
       "INSTANCE_IP": "10.9.8.7",
-      "TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
+      "TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true,
+      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "7202b7c611ebd6d382b7b0240f50e9824200bffd"
     },
     "locality": {
       "zone": "uscentral-5"

--- a/main_test.go
+++ b/main_test.go
@@ -36,7 +36,7 @@ func TestGetGitCommitId(t *testing.T) {
 
 	re := regexp.MustCompile(`^[a-f0-9]{40}$`)
 	if !re.MatchString(commitId) {
-		t.Fatal("getGitCommitId(): returned an invalid commit ID. Want commit ID to be a valid SHA1 hash.")
+		t.Fatalf("getGitCommitId(): returned an invalid commit ID: %q. Want commit ID to be a valid SHA1 hash.", commitId)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -16,12 +16,11 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os/exec"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -29,46 +28,52 @@ import (
 	"github.com/google/uuid"
 )
 
-// Tests to see if the value generated for Node Metadata keyed with
-// `TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA` is the same as the git commit
-// ID of HEAD.
-func TestCommitShaIdInNodeMetadata(t *testing.T) {
-
-	// Build td-grpc-bootstrap binary.
-	cmd := exec.Command("go", "build", ".")
-	if _, err := cmd.Output(); err != nil {
-		t.Fatalf("Error building bootstrap generator: %s", err)
-	}
-
-	// We cannot stub the HTTP calls to Metadata server when executing the
-	// binary this way. Hence passing in arguments so that the generator to exit
-	// with error. Warnings are ignored. The generated config is unmarshalled to c.
-	runCmd := exec.Command("./td-grpc-bootstrap", "--gcp-project-number=1233445")
-	output, err := runCmd.Output()
+func TestGetGitCommitId(t *testing.T) {
+	commitId, err := getGitCommitId()
 	if err != nil {
-		t.Fatalf("Error running bootstrap generator: %s", err)
-	}
-	c := config{}
-	if err = json.Unmarshal([]byte(output), &c); err != nil {
-		t.Fatalf("Error unmarshalling generated output: %s", err)
-	}
-	commitShaUsedInConfig, ok := c.Node.Metadata["TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA"]
-	if !ok {
-		t.Fatal("Error: Key TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA not found in generated config's Node Metadata")
+		t.Fatal(err)
 	}
 
-	// Use git to fetch commit ID of HEAD.
-	gitCmd := exec.Command("git", "rev-parse", "HEAD")
-	commitSha, err := gitCmd.Output()
-	if err != nil {
-		t.Fatalf("Error running git rev-parse: %s", err)
+	re := regexp.MustCompile(`^[a-f0-9]{40}$`)
+	if !re.MatchString(commitId) {
+		t.Fatal("getGitCommitId(): returned an invalid commit ID. Want commit ID to be a valid SHA1 hash.")
 	}
-	// Trim to remove the trailing new line from output.
-	commitShaFromGit := strings.TrimSpace(string(commitSha))
 
-	if diff := cmp.Diff(commitShaFromGit, commitShaUsedInConfig.(string)); diff != "" {
-		t.Fatalf("Error: Commit id in boostrap config (%s) does not match the expected ID (-want +got):\n%s", commitShaUsedInConfig, diff)
-	}
+	// // Build td-grpc-bootstrap binary.
+	// cmd := exec.Command("go", "build", ".")
+	// if _, err := cmd.Output(); err != nil {
+	// 	t.Fatalf("Error building bootstrap generator: %s", err)
+	// }
+
+	// // We cannot stub the HTTP calls to Metadata server when executing the
+	// // binary this way. Hence passing in arguments so that the generator to exit
+	// // with error. Warnings are ignored. The generated config is unmarshalled to c.
+	// runCmd := exec.Command("./td-grpc-bootstrap", "--gcp-project-number=1233445")
+	// output, err := runCmd.Output()
+	// if err != nil {
+	// 	t.Fatalf("Error running bootstrap generator: %s", err)
+	// }
+	// c := config{}
+	// if err = json.Unmarshal([]byte(output), &c); err != nil {
+	// 	t.Fatalf("Error unmarshalling generated output: %s", err)
+	// }
+	// commitShaUsedInConfig, ok := c.Node.Metadata["TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA"]
+	// if !ok {
+	// 	t.Fatal("Error: Key TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA not found in generated config's Node Metadata")
+	// }
+
+	// // Use git to fetch commit ID of HEAD.
+	// gitCmd := exec.Command("git", "rev-parse", "HEAD")
+	// commitSha, err := gitCmd.Output()
+	// if err != nil {
+	// 	t.Fatalf("Error running git rev-parse: %s", err)
+	// }
+	// // Trim to remove the trailing new line from output.
+	// commitShaFromGit := strings.TrimSpace(string(commitSha))
+
+	// if diff := cmp.Diff(commitShaFromGit, commitShaUsedInConfig.(string)); diff != "" {
+	// 	t.Fatalf("Error: Commit id in boostrap config (%s) does not match the expected ID (-want +got):\n%s", commitShaUsedInConfig, diff)
+	// }
 }
 
 func TestValidate(t *testing.T) {

--- a/tools/cloudbuild-artifacts.yaml
+++ b/tools/cloudbuild-artifacts.yaml
@@ -16,7 +16,7 @@ steps:
 - name: golang:1.21
   args: ['go', 'build', '.']
 - name: golang:1.21
-  args: ['go', 'test', './...']
+  args: ['go', 'test', './...', "-buildvcs=true"]
 - name: alpine
   args: ['./tools/package.sh', '$COMMIT_SHA']
 - name: gcr.io/cloud-builders/docker


### PR DESCRIPTION
For some of the features in flight, it would be nice to determine the version of the generator used by looking at the Node metadata that is being passed to TD. This change add a new value to Node.Metadata keyed with `TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA` and is plumbed the git commit ID at HEAD. 