### PR TITLE
Fix MDS url for getClusterLocality

### DIFF
--- a/main.go
+++ b/main.go
@@ -404,7 +404,7 @@ func getClusterName() (string, error) {
 }
 
 func getClusterLocality() (string, error) {
-	locality, err := getFromMetadata("http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-locality")
+	locality, err := getFromMetadata("http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-location")
 	if err != nil {
 		return "", fmt.Errorf("failed to determine GKE cluster locality: %s", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -653,7 +653,7 @@ func TestGetClusterLocality(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			mux := http.NewServeMux()
-			mux.HandleFunc("metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-locality", tt.handler)
+			mux.HandleFunc("metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-location", tt.handler)
 			server := httptest.NewServer(mux)
 			defer server.Close()
 			overrideHTTP(server)


### PR DESCRIPTION
While testing the generator prior to releasing the new `--gke-cluster-location-experimental`, I found that there was a typo in the MDS API endpoint used by `getClusterLocality`. 

I've tested the new changes in a Kubernetes container, please see below 

<details>
<summary>Testing details</summary>

Project name: arvindbright-k8n-test

Cluster name: arvindbright-test-ssa

Pod name: psm-grpc-client-8568fccdc6-44qht

```sh
root@psm-grpc-client-8568fccdc6-44qht:/traffic-director-grpc-bootstrap# ./td-grpc-bootstrap --generate-mesh-id-experimental
{
  "xds_servers": [
    {
      "server_uri": "trafficdirector.googleapis.com:443",
      "channel_creds": [
        {
          "type": "google_default"
        }
      ],
      "server_features": [
        "xds_v3"
      ]
    }
  ],
  "authorities": {
    "traffic-director-c2p.xds.googleapis.com": {
      "xds_servers": [
        {
          "server_uri": "dns:///directpath-pa.googleapis.com",
          "channel_creds": [
            {
              "type": "google_default"
            }
          ],
          "server_features": [
            "xds_v3",
            "ignore_resource_deletion"
          ]
        }
      ],
      "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
    }
  },
  "node": {
    "id": "projects/439293274322/networks/mesh:gsmmesh-b0qq-arvindbright-test-ssa-us-west1-c-b0qq2zt1szea/nodes/8b268b69-7771-4199-afd9-585c5b44563d",
    "cluster": "cluster",
    "metadata": {
      "INSTANCE_IP": "10.124.0.12",
      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "f967c161f666855e6cc52fbec08c90c0188cb8a3"
    },
    "locality": {
      "zone": "us-west1-c"
    }
  },
  "certificate_providers": {
    "google_cloud_private_spiffe": {
      "plugin_name": "file_watcher",
      "config": {
        "certificate_file": "/var/run/secrets/workload-spiffe-credentials/certificates.pem",
        "private_key_file": "/var/run/secrets/workload-spiffe-credentials/private_key.pem",
        "ca_certificate_file": "/var/run/secrets/workload-spiffe-credentials/ca_certificates.pem",
        "refresh_interval": "600s"
      }
    }
  },
  "server_listener_resource_name_template": "grpc/server?xds.resource.listening_address=%s"
}
```


</details>