### PR TITLE
Stabilize GKE related flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,13 +44,13 @@ var (
 	ignoreResourceDeletion     = flag.Bool("ignore-resource-deletion-experimental", false, "assume missing resources notify operators when using Traffic Director, as in gRFC A53. This is not currently the case. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	secretsDir                 = flag.String("secrets-dir", "/var/run/secrets/workload-spiffe-credentials", "path to a directory containing TLS certificates and keys required for PSM security")
 	includeDeploymentInfo      = flag.Bool("include-deployment-info-experimental", false, "whether or not to generate config which contains deployment related information. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	gkeClusterName             = flag.String("gke-cluster-name-experimental", "", "GKE cluster name to use, instead of retrieving it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	gkeClusterName             = flag.String("gke-cluster-name", "", "GKE cluster name to use, instead of retrieving it from the metadata server.")
 	gkePodName                 = flag.String("gke-pod-name-experimental", "", "GKE pod name to use, instead of reading it from $HOSTNAME or /etc/hostname file. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	gkeNamespace               = flag.String("gke-namespace-experimental", "", "GKE namespace to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	gkeLocation                = flag.String("gke-location-experimental", "", "the location (region/zone) of the cluster from which to pull configuration, instead of retrieving it from the metadata server. Locality is used to generate the mesh ID. Ignored if not used with --generate-mesh-id-experimental. This flag is EXPERIMENTAL and may be changed or removed in a later release")
+	gkeLocation                = flag.String("gke-location", "", "the location (region/zone) of the cluster from which to pull configuration, instead of retrieving it from the metadata server. Locality is used to generate the mesh ID. Ignored if not used with --generate-mesh-id.")
 	gceVM                      = flag.String("gce-vm-experimental", "", "GCE VM name to use, instead of reading it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	configMesh                 = flag.String("config-mesh-experimental", "", "Dictates which Mesh resource to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	generateMeshId             = flag.Bool("generate-mesh-id-experimental", false, "When enabled, the CSM MeshID is generated. If config-mesh-experimental flag is specified, this flag would be ignored. Location and Cluster Name would be retrieved from the metadata server unless specified via gke-location-experimental and gke-cluster-name-experimental flags respectively. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	configMesh                 = flag.String("config-mesh", "", "Dictates which Mesh resource to use.")
+	generateMeshId             = flag.Bool("generate-mesh-id", false, "When enabled, the CSM MeshID is generated. If config-mesh flag is specified, this flag would be ignored. Location and Cluster Name would be retrieved from the metadata server unless specified via gke-location and gke-cluster-name flags respectively.")
 	includeDirectPathAuthority = flag.Bool("include-directpath-authority-experimental", true, "whether or not to include DirectPath TD authority for xDS Federation. Ignored if not used with include-federation-support-experimental flag. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	includeXDSTPNameInLDS      = flag.Bool("include-xdstp-name-in-lds-experimental", false, "whether or not to use xdstp style name for listener resource name template. Ignored if not used with include-federation-support-experimental flag. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 )
@@ -64,6 +64,14 @@ func main() {
 		"alias of secrets-dir. This flag is EXPERIMENTAL and will be removed in a later release")
 	flag.Var(flag.Lookup("node-metadata").Value, "node-metadata-experimental",
 		"alias of node-metadata. This flag is EXPERIMENTAL and will be removed in a later release")
+	flag.Var(flag.Lookup("gke-cluster-name").Value, "gke-cluster-name-experimental",
+		"alias of gke-cluster-name. This flag is EXPERIMENTAL and will be removed in a later release")
+	flag.Var(flag.Lookup("gke-location").Value, "gke-location-experimental",
+		"alias of gke-location. This flag is EXPERIMENTAL and will be removed in a later release")
+	flag.Var(flag.Lookup("generate-mesh-id").Value, "generate-mesh-id-experimental",
+		"alias of generate-mesh-id. This flag is EXPERIMENTAL and will be removed in a later release")
+	flag.Var(flag.Lookup("config-mesh").Value, "config-mesh-experimental",
+		"alias of config-mesh. This flag is EXPERIMENTAL and will be removed in a later release")
 
 	flag.Parse()
 
@@ -135,7 +143,7 @@ func main() {
 	meshId := *configMesh
 	if *generateMeshId {
 		if meshId != "" {
-			fmt.Fprint(os.Stderr, "Error: --config-mesh-experimental flag cannot be specified while --generate-mesh-id-experimental is also set.\n")
+			fmt.Fprint(os.Stderr, "Error: --config-mesh flag cannot be specified while --generate-mesh-id is also set.\n")
 			os.Exit(1)
 		}
 

--- a/main.go
+++ b/main.go
@@ -412,7 +412,7 @@ func getClusterName() (string, error) {
 }
 
 func getClusterLocality() (string, error) {
-	locality, err := getFromMetadata("http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-locality")
+	locality, err := getFromMetadata("http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-location")
 	if err != nil {
 		return "", fmt.Errorf("failed to determine GKE cluster locality: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ var (
 	gkeClusterName             = flag.String("gke-cluster-name", "", "GKE cluster name to use, instead of retrieving it from the metadata server.")
 	gkePodName                 = flag.String("gke-pod-name-experimental", "", "GKE pod name to use, instead of reading it from $HOSTNAME or /etc/hostname file. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	gkeNamespace               = flag.String("gke-namespace-experimental", "", "GKE namespace to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	gkeLocation                = flag.String("gke-location", "", "the location (region/zone) of the cluster from which to pull configuration, instead of retrieving it from the metadata server. Locality is used to generate the mesh ID. Ignored if not used with --generate-mesh-id.")
+	gkeLocation                = flag.String("gke-location-experimental", "", "the location (region/zone) of the cluster from which to pull configuration, instead of retrieving it from the metadata server. This value is used to generate the mesh ID. Ignored if not used with --generate-mesh-id. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	gceVM                      = flag.String("gce-vm-experimental", "", "GCE VM name to use, instead of reading it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	configMesh                 = flag.String("config-mesh", "", "Dictates which Mesh resource to use.")
 	generateMeshId             = flag.Bool("generate-mesh-id", false, "When enabled, the CSM MeshID is generated. If config-mesh flag is specified, this flag would be ignored. Location and Cluster Name would be retrieved from the metadata server unless specified via gke-location and gke-cluster-name flags respectively.")
@@ -66,8 +66,6 @@ func main() {
 		"alias of node-metadata. This flag is EXPERIMENTAL and will be removed in a later release")
 	flag.Var(flag.Lookup("gke-cluster-name").Value, "gke-cluster-name-experimental",
 		"alias of gke-cluster-name. This flag is EXPERIMENTAL and will be removed in a later release")
-	flag.Var(flag.Lookup("gke-location").Value, "gke-location-experimental",
-		"alias of gke-location. This flag is EXPERIMENTAL and will be removed in a later release")
 	flag.Var(flag.Lookup("generate-mesh-id").Value, "generate-mesh-id-experimental",
 		"alias of generate-mesh-id. This flag is EXPERIMENTAL and will be removed in a later release")
 	flag.Var(flag.Lookup("config-mesh").Value, "config-mesh-experimental",

--- a/main_test.go
+++ b/main_test.go
@@ -653,7 +653,7 @@ func TestGetClusterLocality(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			mux := http.NewServeMux()
-			mux.HandleFunc("metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-locality", tt.handler)
+			mux.HandleFunc("metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-location", tt.handler)
 			server := httptest.NewServer(mux)
 			defer server.Close()
 			overrideHTTP(server)


### PR DESCRIPTION
As part of the next release, we want to stabilize flags that were introduced as part of CSM release and have been tested. The shape of these flags are not expected to change since they define very specific GKE / CSM related attributes. The flags that are stabilize are the following: 

- `gke-cluster-name`
- `config-mesh`
- `generate-mesh-id`

 I tested to make sure we have backwards compatibility to the `-experimental` flags. 
<details>
<summary>Test details</summary>


Project name: arvindbright-k8n-test

Cluster name: arvindbright-test-ssa

Pod name: psm-grpc-client-8568fccdc6-44qht


```sh
root@psm-grpc-client-8568fccdc6-44qht:/traffic-director-grpc-bootstrap# ./td-grpc-bootstrap --generate-mesh-id
{
  "xds_servers": [
    {
      "server_uri": "trafficdirector.googleapis.com:443",
      "channel_creds": [
        {
          "type": "google_default"
        }
      ],
      "server_features": [
        "xds_v3"
      ]
    }
  ],
  "authorities": {
    "traffic-director-c2p.xds.googleapis.com": {
      "xds_servers": [
        {
          "server_uri": "dns:///directpath-pa.googleapis.com",
          "channel_creds": [
            {
              "type": "google_default"
            }
          ],
          "server_features": [
            "xds_v3",
            "ignore_resource_deletion"
          ]
        }
      ],
      "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
    }
  },
  "node": {
    "id": "projects/439293274322/networks/mesh:gsmmesh-b0qq-arvindbright-test-ssa-us-west1-c-b0qq2zt1szea/nodes/4a939aaa-c2db-4f27-8d46-c33553c87231",
    "cluster": "cluster",
    "metadata": {
      "INSTANCE_IP": "10.124.0.12",
      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "9eb89f3abcd49dd156c6e33f238786257c8326d8"
    },
    "locality": {
      "zone": "us-west1-c"
    }
  },
  "certificate_providers": {
    "google_cloud_private_spiffe": {
      "plugin_name": "file_watcher",
      "config": {
        "certificate_file": "/var/run/secrets/workload-spiffe-credentials/certificates.pem",
        "private_key_file": "/var/run/secrets/workload-spiffe-credentials/private_key.pem",
        "ca_certificate_file": "/var/run/secrets/workload-spiffe-credentials/ca_certificates.pem",
        "refresh_interval": "600s"
      }
    }
  },
  "server_listener_resource_name_template": "grpc/server?xds.resource.listening_address=%s"
}
```


```sh
root@psm-grpc-client-8568fccdc6-44qht:/traffic-director-grpc-bootstrap# ./td-grpc-bootstrap --generate-mesh-id --gke-cluster-name something
{
  "xds_servers": [
    {
      "server_uri": "trafficdirector.googleapis.com:443",
      "channel_creds": [
        {
          "type": "google_default"
        }
      ],
      "server_features": [
        "xds_v3"
      ]
    }
  ],
  "authorities": {
    "traffic-director-c2p.xds.googleapis.com": {
      "xds_servers": [
        {
          "server_uri": "dns:///directpath-pa.googleapis.com",
          "channel_creds": [
            {
              "type": "google_default"
            }
          ],
          "server_features": [
            "xds_v3",
            "ignore_resource_deletion"
          ]
        }
      ],
      "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
    }
  },
  "node": {
    "id": "projects/439293274322/networks/mesh:gsmmesh-dgm2-something-us-west1-c-dgm2uazvapry/nodes/a9ae21c9-d249-45f4-b6aa-11226b40e82b",
    "cluster": "cluster",
    "metadata": {
      "INSTANCE_IP": "10.124.0.12",
      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "9eb89f3abcd49dd156c6e33f238786257c8326d8"
    },
    "locality": {
      "zone": "us-west1-c"
    }
  },
  "certificate_providers": {
    "google_cloud_private_spiffe": {
      "plugin_name": "file_watcher",
      "config": {
        "certificate_file": "/var/run/secrets/workload-spiffe-credentials/certificates.pem",
        "private_key_file": "/var/run/secrets/workload-spiffe-credentials/private_key.pem",
        "ca_certificate_file": "/var/run/secrets/workload-spiffe-credentials/ca_certificates.pem",
        "refresh_interval": "600s"
      }
    }
  },
  "server_listener_resource_name_template": "grpc/server?xds.resource.listening_address=%s"
}

```

```sh
root@psm-grpc-client-8568fccdc6-44qht:/traffic-director-grpc-bootstrap# ./td-grpc-bootstrap --generate-mesh-id-experimental
{
  "xds_servers": [
    {
      "server_uri": "trafficdirector.googleapis.com:443",
      "channel_creds": [
        {
          "type": "google_default"
        }
      ],
      "server_features": [
        "xds_v3"
      ]
    }
  ],
  "authorities": {
    "traffic-director-c2p.xds.googleapis.com": {
      "xds_servers": [
        {
          "server_uri": "dns:///directpath-pa.googleapis.com",
          "channel_creds": [
            {
              "type": "google_default"
            }
          ],
          "server_features": [
            "xds_v3",
            "ignore_resource_deletion"
          ]
        }
      ],
      "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
    }
  },
  "node": {
    "id": "projects/439293274322/networks/mesh:gsmmesh-b0qq-arvindbright-test-ssa-us-west1-c-b0qq2zt1szea/nodes/5a7d864e-5de2-4339-9f4f-7330651529c5",
    "cluster": "cluster",
    "metadata": {
      "INSTANCE_IP": "10.124.0.12",
      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "9eb89f3abcd49dd156c6e33f238786257c8326d8"
    },
    "locality": {
      "zone": "us-west1-c"
    }
  },
  "certificate_providers": {
    "google_cloud_private_spiffe": {
      "plugin_name": "file_watcher",
      "config": {
        "certificate_file": "/var/run/secrets/workload-spiffe-credentials/certificates.pem",
        "private_key_file": "/var/run/secrets/workload-spiffe-credentials/private_key.pem",
        "ca_certificate_file": "/var/run/secrets/workload-spiffe-credentials/ca_certificates.pem",
        "refresh_interval": "600s"
      }
    }
  },
  "server_listener_resource_name_template": "grpc/server?xds.resource.listening_address=%s"
}
```

</details>