### PR TITLE
add ClientDefaultListenerResourceNameTemplate when used with --include-xdstp-name-in-lds-experimental

### DIFF
--- a/main.go
+++ b/main.go
@@ -319,6 +319,7 @@ func generate(in configInput) ([]byte, error) {
 			// xdstp://<authority>/envoy.config.listener.v3.Listener/<project_number>/<(network)|(mesh:mesh_name)>/id
 			ClientListenerResourceNameTemplate: fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%d/%s/%%s", tdAuthority, in.gcpProjectNumber, networkIdentifier),
 		}
+		c.ClientDefaultListenerResourceNameTemplate = fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%d/%s/%%s", tdAuthority, in.gcpProjectNumber, networkIdentifier)
 	}
 
 	c2pAuthority := "traffic-director-c2p.xds.googleapis.com"
@@ -462,11 +463,12 @@ func getFromMetadata(urlStr string) ([]byte, error) {
 }
 
 type config struct {
-	XdsServers                         []server                             `json:"xds_servers,omitempty"`
-	Authorities                        map[string]Authority                 `json:"authorities,omitempty"`
-	Node                               *node                                `json:"node,omitempty"`
-	CertificateProviders               map[string]certificateProviderConfig `json:"certificate_providers,omitempty"`
-	ServerListenerResourceNameTemplate string                               `json:"server_listener_resource_name_template,omitempty"`
+	XdsServers                                []server                             `json:"xds_servers,omitempty"`
+	Authorities                               map[string]Authority                 `json:"authorities,omitempty"`
+	Node                                      *node                                `json:"node,omitempty"`
+	CertificateProviders                      map[string]certificateProviderConfig `json:"certificate_providers,omitempty"`
+	ServerListenerResourceNameTemplate        string                               `json:"server_listener_resource_name_template,omitempty"`
+	ClientDefaultListenerResourceNameTemplate string                               `json:"client_default_listener_resource_name_template,omitempty"`
 }
 
 type server struct {

--- a/main_test.go
+++ b/main_test.go
@@ -553,7 +553,8 @@ func TestGenerate(t *testing.T) {
       }
     }
   },
-  "server_listener_resource_name_template": "grpc/server?xds.resource.listening_address=%s"
+  "server_listener_resource_name_template": "grpc/server?xds.resource.listening_address=%s",
+  "client_default_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/123456789012345/thedefault/%s"
 }`,
 		},
 	}


### PR DESCRIPTION
`--include-xdstp-name-in-lds-experimental` currently only adds in the TDOM authority to the authorities map. For xDS dial targets without an authority to default to the new xDSTP style name and use the TDOM authority, the flag should add `client_default_listener_resource_name_template` to the config.

#### Behavior changes to gRPC client after this change:  

##### Example 1: When no authority specified in dial target

If a gRPC client channel is created for `xds:server.example.com`

- The target URI specifies no authority, so we use the `client_default_listener_resource_name_template` field. The resulting resource name will be `xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/123456789012345/thedefault/server.example.com`.
- The resource name specifies the TDOM authority, so that's the entry we use from the `authorities` map.
- We do not use the `client_listener_resource_name_template` field in the `authorities` entry, since we've already used the top-level `client_default_listener_resource_name_template` field to construct the resource name.
- The `xds_server` list is not specified in the entry for the authority, so we default to the top-level `xds_server` list, which is the same one that we would have used prior to this design.

##### Example 2: When TDOM authority specified in dial target

If a gRPC client channel is created for `xds://traffic-director-global.xds.googleapis.com/server.example.com`

- The resource name specifies the TDOM authority, so that's the entry we use from the `authorities` map.
- We use the `client_listener_resource_name_template` field in the `authorities` entry to construct the resource name which results in `xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/123456789012345/thedefault/server.example.com`.
- The `xds_server` list is not specified in the entry for the authority, so we default to the top-level `xds_server` list, which is the same one that we would have used prior to this design.


Path to stabilizing this flag:

- Setup a simple PSM setup in GCP 
- Verify with grpcurl for the 2 types of dial targets (with and without authority) 
