### PR TITLE
cloudbuild: Publish preprod image to Artifact Registry

### DIFF
--- a/tools/cloudbuild-artifacts.yaml
+++ b/tools/cloudbuild-artifacts.yaml
@@ -20,7 +20,7 @@ steps:
 - name: alpine
   args: ['./tools/package.sh', '$COMMIT_SHA']
 - name: gcr.io/cloud-builders/docker
-  args: [ 'build', '-t', 'gcr.io/grpc-testing/td-grpc-bootstrap:${COMMIT_SHA}', '.' ]
+  args: [ 'build', '-t', 'us-docker.pkg.dev/grpc-testing/trafficdirector/td-grpc-bootstrap:${COMMIT_SHA}', '.' ]
 options:
   env:
   - CGO_ENABLED=0
@@ -28,4 +28,4 @@ artifacts:
   objects:
     location: 'gs://grpc-td-builds/td-grpc-bootstrap/'
     paths: ['td-grpc-bootstrap-${COMMIT_SHA}.tar.gz']
-images: ['gcr.io/grpc-testing/td-grpc-bootstrap:${COMMIT_SHA}']
+images: ['us-docker.pkg.dev/grpc-testing/trafficdirector/td-grpc-bootstrap:${COMMIT_SHA}']


### PR DESCRIPTION
Migrates TD gRPC bootstrap from Container Registry (gcr.io) to Artifact Registry (pkg.dev). Container Registry deprecation notice: https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation.

All preprod images are from gcr.io/grpc-testing/td-grpc-bootstrap to us-docker.pkg.dev/grpc-testing/trafficdirector/td-grpc-bootstrap.

This updates cloudbuild config to publish all new preprod images to Artifact Registry.