### PR TITLE
Add trusted_xds_server server feature for TD

### DIFF
--- a/main.go
+++ b/main.go
@@ -259,8 +259,8 @@ func generate(in configInput) ([]byte, error) {
 		ChannelCreds: []creds{{Type: "google_default"}},
 	}
 
-	// Set xds_v3 Server Features.
-	xdsServer.ServerFeatures = append(xdsServer.ServerFeatures, "xds_v3")
+	// Set xds_v3 and trusted Server Features.
+	xdsServer.ServerFeatures = append(xdsServer.ServerFeatures, "xds_v3", "trusted_xds_server")
 
 	if in.ignoreResourceDeletion {
 		xdsServer.ServerFeatures = append(xdsServer.ServerFeatures, "ignore_resource_deletion")

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ var (
 	configMesh             = flag.String("config-mesh", "", "Dictates which Mesh resource to use.")
 	generateMeshId         = flag.Bool("generate-mesh-id", false, "When enabled, the CSM MeshID is generated. If config-mesh flag is specified, this flag would be ignored. Location and Cluster Name would be retrieved from the metadata server unless specified via gke-location and gke-cluster-name flags respectively.")
 	includeXDSTPNameInLDS  = flag.Bool("include-xdstp-name-in-lds-experimental", true, "whether or not to use xdstp style name for listener resource name template. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	isTrustedXdsServer     = flag.Bool("is-trusted-xds-server", false, "Whether to include the server feature trusted_xds_server for TD.")
 )
 
 func main() {
@@ -189,6 +190,7 @@ func main() {
 		ipv6Capable:            isIPv6Capable(),
 		includeXDSTPNameInLDS:  *includeXDSTPNameInLDS,
 		gitCommitHash:          gitCommitHash,
+		isTrustedXdsServer:     *isTrustedXdsServer,
 	}
 
 	if err := validate(input); err != nil {
@@ -242,6 +244,7 @@ type configInput struct {
 	ipv6Capable            bool
 	includeXDSTPNameInLDS  bool
 	gitCommitHash          string
+	isTrustedXdsServer     bool
 }
 
 func validate(in configInput) error {
@@ -259,8 +262,11 @@ func generate(in configInput) ([]byte, error) {
 		ChannelCreds: []creds{{Type: "google_default"}},
 	}
 
-	// Set xds_v3 and trusted Server Features.
-	xdsServer.ServerFeatures = append(xdsServer.ServerFeatures, "xds_v3", "trusted_xds_server")
+	// Set xds_v3.
+	xdsServer.ServerFeatures = append(xdsServer.ServerFeatures, "xds_v3")
+	if in.isTrustedXdsServer {
+	  xdsServer.ServerFeatures = append(xdsServer.ServerFeatures, "trusted_xds_server")
+	}
 
 	if in.ignoreResourceDeletion {
 		xdsServer.ServerFeatures = append(xdsServer.ServerFeatures, "ignore_resource_deletion")

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ var (
 	configMesh             = flag.String("config-mesh", "", "Dictates which Mesh resource to use.")
 	generateMeshId         = flag.Bool("generate-mesh-id", false, "When enabled, the CSM MeshID is generated. If config-mesh flag is specified, this flag would be ignored. Location and Cluster Name would be retrieved from the metadata server unless specified via gke-location and gke-cluster-name flags respectively.")
 	includeXDSTPNameInLDS  = flag.Bool("include-xdstp-name-in-lds-experimental", true, "whether or not to use xdstp style name for listener resource name template. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	isTrustedXdsServer     = flag.Bool("is-trusted-xds-server", false, "Whether to include the server feature trusted_xds_server for TD.")
+	isTrustedXdsServer     = flag.Bool("is-trusted-xds-server-experimental", false, "Whether to include the server feature trusted_xds_server for TD. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 )
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -124,6 +124,78 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
+        "xds_v3"
+      ]
+    }
+  ],
+  "authorities": {
+    "traffic-director-c2p.xds.googleapis.com": {
+      "xds_servers": [
+        {
+          "server_uri": "dns:///directpath-pa.googleapis.com",
+          "channel_creds": [
+            {
+              "type": "google_default"
+            }
+          ],
+          "server_features": [
+            "xds_v3",
+            "ignore_resource_deletion"
+          ]
+        }
+      ],
+      "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
+    }
+  },
+  "node": {
+    "id": "projects/123456789012345/networks/thedefault/nodes/52fdfc07-2182-454f-963f-5f0f9a621d72",
+    "cluster": "cluster",
+    "metadata": {
+      "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "7202b7c611ebd6d382b7b0240f50e9824200bffd",
+      "k1": "v1",
+      "k2": "v2"
+    },
+    "locality": {
+      "zone": "uscentral-5"
+    }
+  },
+  "certificate_providers": {
+    "google_cloud_private_spiffe": {
+      "plugin_name": "file_watcher",
+      "config": {
+        "certificate_file": "certificates.pem",
+        "private_key_file": "private_key.pem",
+        "ca_certificate_file": "ca_certificates.pem",
+        "refresh_interval": "600s"
+      }
+    }
+  },
+  "server_listener_resource_name_template": "grpc/server?xds.resource.listening_address=%s"
+}`,
+		},
+		{
+			desc: "Server feature for Trusted xds server",
+			input: configInput{
+				xdsServerUri:     "example.com:443",
+				gcpProjectNumber: 123456789012345,
+				vpcNetworkName:   "thedefault",
+				ip:               "10.9.8.7",
+				zone:             "uscentral-5",
+				metadataLabels:   map[string]string{"k1": "v1", "k2": "v2"},
+				gitCommitHash:    "7202b7c611ebd6d382b7b0240f50e9824200bffd",
+				isTrustedXdsServer: true,
+			},
+			wantOutput: `{
+  "xds_servers": [
+    {
+      "server_uri": "example.com:443",
+      "channel_creds": [
+        {
+          "type": "google_default"
+        }
+      ],
+      "server_features": [
         "xds_v3",
         "trusted_xds_server"
       ]
@@ -196,8 +268,7 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3",
-        "trusted_xds_server"
+        "xds_v3"
       ]
     }
   ],
@@ -273,8 +344,7 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3",
-        "trusted_xds_server"
+        "xds_v3"
       ]
     }
   ],
@@ -359,8 +429,7 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3",
-        "trusted_xds_server"
+        "xds_v3"
       ]
     }
   ],
@@ -438,7 +507,6 @@ func TestGenerate(t *testing.T) {
       ],
       "server_features": [
         "xds_v3",
-        "trusted_xds_server",
         "ignore_resource_deletion"
       ]
     }
@@ -509,8 +577,7 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3",
-        "trusted_xds_server"
+        "xds_v3"
       ]
     }
   ],

--- a/main_test.go
+++ b/main_test.go
@@ -124,7 +124,7 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3"
+        "xds_v3", "trusted_xds_server"
       ]
     }
   ],
@@ -195,7 +195,7 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3"
+        "xds_v3", "trusted_xds_server"
       ]
     }
   ],
@@ -271,7 +271,7 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3"
+        "xds_v3", "trusted_xds_server"
       ]
     }
   ],
@@ -356,7 +356,7 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3"
+        "xds_v3", "trusted_xds_server"
       ]
     }
   ],
@@ -434,7 +434,8 @@ func TestGenerate(t *testing.T) {
       ],
       "server_features": [
         "xds_v3",
-        "ignore_resource_deletion"
+        "ignore_resource_deletion",
+        "trusted_xds_server"
       ]
     }
   ],
@@ -504,7 +505,7 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3"
+        "xds_v3", "trusted_xds_server"
       ]
     }
   ],

--- a/main_test.go
+++ b/main_test.go
@@ -124,7 +124,8 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3", "trusted_xds_server"
+        "xds_v3",
+        "trusted_xds_server"
       ]
     }
   ],
@@ -195,7 +196,8 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3", "trusted_xds_server"
+        "xds_v3",
+        "trusted_xds_server"
       ]
     }
   ],
@@ -271,7 +273,8 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3", "trusted_xds_server"
+        "xds_v3",
+        "trusted_xds_server"
       ]
     }
   ],
@@ -356,7 +359,8 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3", "trusted_xds_server"
+        "xds_v3",
+        "trusted_xds_server"
       ]
     }
   ],
@@ -434,8 +438,8 @@ func TestGenerate(t *testing.T) {
       ],
       "server_features": [
         "xds_v3",
-        "ignore_resource_deletion",
-        "trusted_xds_server"
+        "trusted_xds_server",
+        "ignore_resource_deletion"
       ]
     }
   ],
@@ -505,7 +509,8 @@ func TestGenerate(t *testing.T) {
         }
       ],
       "server_features": [
-        "xds_v3", "trusted_xds_server"
+        "xds_v3",
+        "trusted_xds_server"
       ]
     }
   ],


### PR DESCRIPTION
In order to address use-cases where authority rewriting may not be acceptable from a security perspective, adding a new server feature to the bootstrap config. The server feature is  specfied via the server_features field described in [gRFC A30](https://github.com/grpc/proposal/blob/master/A30-xds-v3.md). The feature is the string trusted_xds_server. (Note that the name is intentionally fairly general, since it may be used to trigger other security-sensitive functionality in the future.)