### PR TITLE
make GKE-NAMESPACE an optional entry in TRAFFIC_DIRECTOR_CLIENT_ENVIRONMENT Node Metadata

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,12 +127,14 @@ func main() {
 				}
 			}
 			deploymentInfo = map[string]string{
-				"GKE-CLUSTER":   cluster,
-				"GKE-LOCATION":  clusterLocation,
-				"GCP-ZONE":      zone,
-				"INSTANCE-IP":   ip,
-				"GKE-POD":       pod,
-				"GKE-NAMESPACE": *gkeNamespace,
+				"GKE-CLUSTER":  cluster,
+				"GKE-LOCATION": clusterLocation,
+				"GCP-ZONE":     zone,
+				"INSTANCE-IP":  ip,
+				"GKE-POD":      pod,
+			}
+			if *gkeNamespace != "" {
+				deploymentInfo["GKE-NAMESPACE"] = *gkeNamespace
 			}
 		case deploymentTypeGCE:
 			vmName := *gceVM


### PR DESCRIPTION
GKE-NAMESPACE is a user input field and would be empty if not specified. This change would make this entry optional if the input value were empty. 