### PR TITLE
Use distroless/static as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM scratch
+FROM gcr.io/distroless/static
 COPY td-grpc-bootstrap ./
 ENTRYPOINT ["/td-grpc-bootstrap"]


### PR DESCRIPTION
This is to make scanning tools happy, that only know about a limited number of distros (b/366296183). Previously the image wasn't a proper OCI because it lacked os-release and such, but that also isn't the root of the problem. This new base image has ca-certificates, /tmp, and tzdata, none of which do we actually want to use. This appears to be the lowest-dependency base image understood by the scanning tool.

CC @arvindbr8