### PR TITLE
Add GOOGLE_INTERNAL_GSM_NAMESPACE and GOOGLE_INTERNAL_GSM_DEPLOYMENT to node metadata,

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ var (
 	gkePodName             = flag.String("gke-pod-name-experimental", "", "GKE pod name to use, instead of reading it from $HOSTNAME or /etc/hostname file. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	gkeNamespace           = flag.String("gke-namespace-experimental", "", "GKE namespace to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	gkeLocation            = flag.String("gke-location-experimental", "", "the location (region/zone) of the GKE cluster, instead of retrieving it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	gkeDeployment          = flag.String("gke-deployment-experimental", "", "GKE deployment to use. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	gceVM                  = flag.String("gce-vm-experimental", "", "GCE VM name to use, instead of reading it from the metadata server. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 	configMesh             = flag.String("config-mesh", "", "Dictates which Mesh resource to use.")
 	generateMeshId         = flag.Bool("generate-mesh-id", false, "When enabled, the CSM MeshID is generated. If config-mesh flag is specified, this flag would be ignored. Location and Cluster Name would be retrieved from the metadata server unless specified via gke-location and gke-cluster-name flags respectively.")
@@ -190,6 +191,13 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: unable to determine git commit ID: %s\n", err)
 		os.Exit(1)
+	}
+
+	if *gkeNamespace != "" {
+		nodeMetadata["GOOGLE_INTERNAL_GSM_NAMESPACE"] = *gkeNamespace
+	}
+	if *gkeDeployment != "" {
+		nodeMetadata["GOOGLE_INTERNAL_GSM_DEPLOYMENT"] = *gkeDeployment
 	}
 
 	input := configInput{

--- a/main_test.go
+++ b/main_test.go
@@ -181,12 +181,17 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "Server feature for Trusted xds server",
 			input: configInput{
-				xdsServerUri:       "example.com:443",
-				gcpProjectNumber:   123456789012345,
-				vpcNetworkName:     "thedefault",
-				ip:                 "10.9.8.7",
-				zone:               "uscentral-5",
-				metadataLabels:     map[string]string{"k1": "v1", "k2": "v2"},
+				xdsServerUri:     "example.com:443",
+				gcpProjectNumber: 123456789012345,
+				vpcNetworkName:   "thedefault",
+				ip:               "10.9.8.7",
+				zone:             "uscentral-5",
+				metadataLabels: map[string]string{
+					"k1":                             "v1",
+					"k2":                             "v2",
+					"GOOGLE_INTERNAL_GSM_NAMESPACE":  "test-ns",
+					"GOOGLE_INTERNAL_GSM_DEPLOYMENT": "test-deployment",
+				},
 				gitCommitHash:      "7202b7c611ebd6d382b7b0240f50e9824200bffd",
 				isTrustedXdsServer: true,
 			},
@@ -231,6 +236,8 @@ func TestGenerate(t *testing.T) {
     "id": "projects/123456789012345/networks/thedefault/nodes/52fdfc07-2182-454f-963f-5f0f9a621d72",
     "cluster": "cluster",
     "metadata": {
+      "GOOGLE_INTERNAL_GSM_DEPLOYMENT": "test-deployment",
+      "GOOGLE_INTERNAL_GSM_NAMESPACE": "test-ns",
       "INSTANCE_IP": "10.9.8.7",
       "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "7202b7c611ebd6d382b7b0240f50e9824200bffd",
       "k1": "v1",


### PR DESCRIPTION
This will be used for apply authorization policies to deployments. Used only in CSM Gateway API cluster.