### PR TITLE
chore: minor cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ gcr.io/trafficdirector-prod/td-grpc-bootstrap
 
 Please refer to the [GKE setup guide](https://cloud.google.com/traffic-director/docs/set-up-proxyless-gke)
 for more details.
+
+## Running unit tests
+
+To run unit tests, run the following command:
+```
+go test ./... -buildvcs=true
+```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ for more details.
 ## Running unit tests
 
 To run unit tests, run the following command:
-```
+```shell
 go test ./... -buildvcs=true
 ```

--- a/deployment_info.go
+++ b/deployment_info.go
@@ -33,14 +33,14 @@ const (
 // http://metadata.google.internal and uses a response header with key "Server"
 // to determine the deployment type.
 func getDeploymentType() (deploymentType, error) {
-	parsedUrl, err := url.Parse("http://metadata.google.internal")
+	parsedURL, err := url.Parse("http://metadata.google.internal")
 	if err != nil {
 		return deploymentTypeUnknown, err
 	}
 	client := &http.Client{Timeout: 5 * time.Second}
 	req := &http.Request{
 		Method: "GET",
-		URL:    parsedUrl,
+		URL:    parsedURL,
 		Header: http.Header{"Metadata-Flavor": {"Google"}},
 	}
 	resp, err := client.Do(req)

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ var (
 	configMesh                 = flag.String("config-mesh", "", "Dictates which Mesh resource to use.")
 	generateMeshID             = flag.Bool("generate-mesh-id", false, "When enabled, the CSM MeshID is generated. If config-mesh flag is specified, this flag would be ignored. Location and Cluster Name would be retrieved from the metadata server unless specified via gke-location and gke-cluster-name flags respectively.")
 	includeAllowedGrpcServices = flag.Bool("include-allowed-grpc-services-experimental", false, "When enabled, generates `allowed_grpc_services` map that includes current xDS Server URI. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
-	isTrustedXdsServer         = flag.Bool("is-trusted-xds-server-experimental", false, "Whether to include the server feature trusted_xds_server for TD. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
+	isTrustedXDSServer         = flag.Bool("is-trusted-xds-server-experimental", false, "Whether to include the server feature trusted_xds_server for TD. This flag is EXPERIMENTAL and may be changed or removed in a later release.")
 )
 
 const (
@@ -91,7 +91,7 @@ func main() {
 
 	ip, err := getHostIP()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to determine host's ip: %s\n", err)
+		fmt.Fprintf(os.Stderr, "Warning: failed to determine host's IP: %s\n", err)
 	}
 
 	// Retrieve zone from the metadata server only if not specified in args.
@@ -205,7 +205,7 @@ func main() {
 		configMesh:                 meshID,
 		ipv6Capable:                isIPv6Capable(),
 		gitCommitHash:              gitCommitHash,
-		isTrustedXdsServer:         *isTrustedXdsServer,
+		isTrustedXDSServer:         *isTrustedXDSServer,
 		includeAllowedGrpcServices: *includeAllowedGrpcServices,
 	}
 
@@ -259,7 +259,7 @@ type configInput struct {
 	configMesh                 string
 	ipv6Capable                bool
 	gitCommitHash              string
-	isTrustedXdsServer         bool
+	isTrustedXDSServer         bool
 	includeAllowedGrpcServices bool
 }
 
@@ -280,7 +280,7 @@ func generate(in configInput) ([]byte, error) {
 
 	// Set xds_v3.
 	xdsServer.ServerFeatures = append(xdsServer.ServerFeatures, "xds_v3")
-	if in.isTrustedXdsServer {
+	if in.isTrustedXDSServer {
 		xdsServer.ServerFeatures = append(xdsServer.ServerFeatures, "trusted_xds_server")
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -20,25 +20,12 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 )
-
-func TestGetGitCommitId(t *testing.T) {
-	commitId, err := getGitCommitId()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	re := regexp.MustCompile(`^[a-f0-9]{40}$`)
-	if !re.MatchString(commitId) {
-		t.Fatalf("getGitCommitId(): returned an invalid commit ID: %q. Want commit ID to be a valid SHA1 hash.", commitId)
-	}
-}
 
 func TestValidate(t *testing.T) {
 	tests := []struct {
@@ -49,7 +36,7 @@ func TestValidate(t *testing.T) {
 		{
 			desc: "fails when config-mesh has too many characters",
 			input: configInput{
-				xdsServerUri:     "example.com:443",
+				xdsServerURI:     "example.com:443",
 				gcpProjectNumber: 123456789012345,
 				vpcNetworkName:   "thedefault",
 				ip:               "10.9.8.7",
@@ -62,7 +49,7 @@ func TestValidate(t *testing.T) {
 		{
 			desc: "fails when config-mesh does not start with an alphabetic letter",
 			input: configInput{
-				xdsServerUri:     "example.com:443",
+				xdsServerURI:     "example.com:443",
 				gcpProjectNumber: 123456789012345,
 				vpcNetworkName:   "thedefault",
 				ip:               "10.9.8.7",
@@ -75,7 +62,7 @@ func TestValidate(t *testing.T) {
 		{
 			desc: "fails when config-mesh contains characters besides letters, numbers, and hyphens.",
 			input: configInput{
-				xdsServerUri:     "example.com:443",
+				xdsServerURI:     "example.com:443",
 				gcpProjectNumber: 123456789012345,
 				vpcNetworkName:   "thedefault",
 				ip:               "10.9.8.7",
@@ -106,7 +93,7 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "happy case with v3 config by default",
 			input: configInput{
-				xdsServerUri:     "example.com:443",
+				xdsServerURI:     "example.com:443",
 				gcpProjectNumber: 123456789012345,
 				vpcNetworkName:   "thedefault",
 				ip:               "10.9.8.7",
@@ -181,7 +168,7 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "Server feature for Trusted xds server",
 			input: configInput{
-				xdsServerUri:       "example.com:443",
+				xdsServerURI:       "example.com:443",
 				gcpProjectNumber:   123456789012345,
 				vpcNetworkName:     "thedefault",
 				ip:                 "10.9.8.7",
@@ -258,7 +245,7 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "happy case with security config",
 			input: configInput{
-				xdsServerUri:     "example.com:443",
+				xdsServerURI:     "example.com:443",
 				gcpProjectNumber: 123456789012345,
 				vpcNetworkName:   "thedefault",
 				ip:               "10.9.8.7",
@@ -331,7 +318,7 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "happy case with deployment info",
 			input: configInput{
-				xdsServerUri:     "example.com:443",
+				xdsServerURI:     "example.com:443",
 				gcpProjectNumber: 123456789012345,
 				vpcNetworkName:   "thedefault",
 				ip:               "10.9.8.7",
@@ -419,7 +406,7 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "configMesh specified",
 			input: configInput{
-				xdsServerUri:     "example.com:443",
+				xdsServerURI:     "example.com:443",
 				gcpProjectNumber: 123456789012345,
 				vpcNetworkName:   "thedefault",
 				ip:               "10.9.8.7",
@@ -508,7 +495,7 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "ignore_resource_deletion and v3",
 			input: configInput{
-				xdsServerUri:           "example.com:443",
+				xdsServerURI:           "example.com:443",
 				gcpProjectNumber:       123456789012345,
 				vpcNetworkName:         "thedefault",
 				ip:                     "10.9.8.7",
@@ -582,7 +569,7 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "happy path for allowed_grpc_services",
 			input: configInput{
-				xdsServerUri:               "example.com:443",
+				xdsServerURI:               "example.com:443",
 				gcpProjectNumber:           123456789012345,
 				vpcNetworkName:             "thedefault",
 				ip:                         "10.9.8.7",
@@ -713,7 +700,7 @@ func TestGetProjectId(t *testing.T) {
 			}
 			w.Write([]byte("123456789012345"))
 		})
-	got, err := getProjectId()
+	got, err := getProjectID()
 	if err != nil {
 		t.Fatalf("want no error, got :%v", err)
 	}
@@ -868,7 +855,7 @@ func overrideHTTP(s *httptest.Server) {
 func Test_getQualifiedXdsUri(t *testing.T) {
 	tests := []struct {
 		name         string
-		xdsServerUri string
+		xdsServerURI string
 		want         string
 	}{
 		{"append when missing dns:", "example.com:123", "dns:///example.com:123"},
@@ -876,7 +863,7 @@ func Test_getQualifiedXdsUri(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getQualifiedXdsUri(tt.xdsServerUri); got != tt.want {
+			if got := getQualifiedXDSURI(tt.xdsServerURI); got != tt.want {
 				t.Errorf("getQualifiedXdsUri() = %v, want %v", got, tt.want)
 			}
 		})

--- a/main_test.go
+++ b/main_test.go
@@ -175,7 +175,7 @@ func TestGenerate(t *testing.T) {
 				zone:               "uscentral-5",
 				metadataLabels:     map[string]string{"k1": "v1", "k2": "v2"},
 				gitCommitHash:      "7202b7c611ebd6d382b7b0240f50e9824200bffd",
-				isTrustedXdsServer: true,
+				isTrustedXDSServer: true,
 			},
 			wantOutput: `{
   "xds_servers": [

--- a/version.go
+++ b/version.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+// getCommitID returns the commit ID of the current build, or an error if it
+// cannot be determined. It reads the "vcs.revision" setting from the
+// runtime.BuildInfo and returns that value.
+func getCommitID() (string, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", fmt.Errorf("error calling debug.ReadBuildInfo")
+	}
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" {
+			return setting.Value, nil
+		}
+	}
+	return "", fmt.Errorf("BuildInfo.Settings is missing vcs.revision")
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,32 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestGetCommitId(t *testing.T) {
+	commitId, err := getCommitID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	re := regexp.MustCompile(`^[a-f0-9]{40}$`)
+	if !re.MatchString(commitId) {
+		t.Fatalf("getCommitId(): returned an invalid commit ID: %q. Want commit ID to be a valid SHA1 hash.", commitId)
+	}
+}

--- a/version_test.go
+++ b/version_test.go
@@ -20,13 +20,13 @@ import (
 )
 
 func TestGetCommitId(t *testing.T) {
-	commitId, err := getCommitID()
+	commitID, err := getCommitID()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	re := regexp.MustCompile(`^[a-f0-9]{40}$`)
-	if !re.MatchString(commitId) {
-		t.Fatalf("getCommitId(): returned an invalid commit ID: %q. Want commit ID to be a valid SHA1 hash.", commitId)
+	if !re.MatchString(commitID) {
+		t.Fatalf("getCommitId(): returned an invalid commit ID: %q. Want commit ID to be a valid SHA1 hash.", commitID)
 	}
 }


### PR DESCRIPTION
Cleanups include the following:
- Add a section to the README to specify the command to use to run unit tests (since it needs the -buildvcs=true flag)
- Comply with the Go initialisms style guide recommendation to make the linter happy. See: https://google.github.io/styleguide/go/decisions#initialisms
- Add a package level comment for the `main` package
- Switch `interface{}` to `any` to make the linter happy
- Move the function used to get the commit ID of the current build to a separate file. This can be swapped out with a different implementation in a different environment.