### PR TITLE
Upgrade golang version

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,14 +7,22 @@ permissions:
   contents: read
 
 jobs:
-  tests:
+  tests-latest:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.26
+          go-version: 1.26.2
+      - name: Run tests (latest)
+        run: go test -v ./... -buildvcs=true
 
-      - name: Run tests
+  tests-earliest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.25
+      - name: Run tests (latest)
         run: go test -v ./... -buildvcs=true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module td-grpc-bootstrap
 
-go 1.21
+go 1.25
 
 require (
 	github.com/google/go-cmp v0.5.4

--- a/tools/cloudbuild-artifacts.yaml
+++ b/tools/cloudbuild-artifacts.yaml
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 steps:
-- name: golang:1.26
+- name: golang:1.26.2
   args: ['go', 'build', '.']
-- name: golang:1.26
+- name: golang:1.26.2
   args: ['go', 'test', './...', "-buildvcs=true"]
 - name: alpine
   args: ['./tools/package.sh', '$COMMIT_SHA']


### PR DESCRIPTION
This PR makes the following changes:
- Change the golang version to 1.26.2 in the container image built using Cloud Build
- Change the golang version to 1.26.2 in the tests
  - Also, add another test job to test on the minimum supported version  
- Change the minimum supported golang version to 1.25 in the go.mod
  - Since we get two major releases of Go every year, making the previous version the minimum supported version, gives us a year of support.