### PR TITLE
Fix regional authority ServerURI generation to respect --xds-server-uri overrides

### DIFF
--- a/main.go
+++ b/main.go
@@ -338,7 +338,9 @@ func generate(in configInput) ([]byte, error) {
 	if in.xdsServerRegion != "" {
 		regionalTdAuthority := fmt.Sprintf("traffic-director.%s.xds.googleapis.com", in.xdsServerRegion)
 		regionalXdsServer := xdsServer
-		regionalXdsServer.ServerURI = fmt.Sprintf("trafficdirector.%s.rep.googleapis.com:443", in.xdsServerRegion)
+		if !strings.Contains(regionalXdsServer.ServerURI, in.xdsServerRegion) {
+			regionalXdsServer.ServerURI = fmt.Sprintf("trafficdirector.%s.rep.googleapis.com:443", in.xdsServerRegion)
+		}
 
 		c.Authorities[regionalTdAuthority] = Authority{
 			XDSServers: []server{regionalXdsServer},

--- a/main_test.go
+++ b/main_test.go
@@ -263,6 +263,95 @@ func TestGenerate(t *testing.T) {
 }`,
 		},
 		{
+			desc: "happy case with staging regional config setup",
+			input: configInput{
+				xdsServerURI:     "staging-trafficdirector.antarctica-central1.rep.sandbox.googleapis.com:443",
+				gcpProjectNumber: 123,
+				vpcNetworkName:   "test",
+				ip:               "10.9.8.7",
+				zone:             "antarctica-central1",
+				gitCommitHash:    "12345",
+				xdsServerRegion:  "antarctica-central1",
+			},
+			wantOutput: `{
+  "xds_servers": [
+    {
+      "server_uri": "staging-trafficdirector.antarctica-central1.rep.sandbox.googleapis.com:443",
+      "channel_creds": [
+        {
+          "type": "google_default"
+        }
+      ],
+      "server_features": [
+        "xds_v3"
+      ]
+    }
+  ],
+  "authorities": {
+    "traffic-director-c2p.xds.googleapis.com": {
+      "xds_servers": [
+        {
+          "server_uri": "dns:///directpath-pa.googleapis.com",
+          "channel_creds": [
+            {
+              "type": "google_default"
+            }
+          ],
+          "server_features": [
+            "xds_v3",
+            "ignore_resource_deletion"
+          ]
+        }
+      ],
+      "client_listener_resource_name_template": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s"
+    },
+    "traffic-director-global.xds.googleapis.com": {
+      "client_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/123/test/%s"
+    },
+    "traffic-director.antarctica-central1.xds.googleapis.com": {
+      "xds_servers": [
+        {
+          "server_uri": "staging-trafficdirector.antarctica-central1.rep.sandbox.googleapis.com:443",
+          "channel_creds": [
+            {
+              "type": "google_default"
+            }
+          ],
+          "server_features": [
+            "xds_v3"
+          ]
+        }
+      ],
+      "client_listener_resource_name_template": "xdstp://traffic-director.antarctica-central1.xds.googleapis.com/envoy.config.listener.v3.Listener/123/test/%s"
+    }
+  },
+  "node": {
+    "id": "projects/123/networks/test/nodes/52fdfc07-2182-454f-963f-5f0f9a621d72",
+    "cluster": "cluster",
+    "metadata": {
+      "INSTANCE_IP": "10.9.8.7",
+      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "12345"
+    },
+    "locality": {
+      "zone": "antarctica-central1"
+    }
+  },
+  "certificate_providers": {
+    "google_cloud_private_spiffe": {
+      "plugin_name": "file_watcher",
+      "config": {
+        "certificate_file": "certificates.pem",
+        "private_key_file": "private_key.pem",
+        "ca_certificate_file": "ca_certificates.pem",
+        "refresh_interval": "600s"
+      }
+    }
+  },
+  "server_listener_resource_name_template": "grpc/server?xds.resource.listening_address=%s",
+  "client_default_listener_resource_name_template": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/123/test/%s"
+}`,
+		},
+		{
 			desc: "Server feature for Trusted xds server",
 			input: configInput{
 				xdsServerURI:       "example.com:443",


### PR DESCRIPTION
cl/947945886 has some context on staging failure that was seen.

When --xds-server-region is used alongside --xds-server-uri (e.g., when targeting staging sandboxes), the generator previously hardcoded the regional authority's ServerURI to production (trafficdirector.<region>.rep.googleapis.com:443). This caused gRPC clients attempting regional xDS lookups to connect to production instead of the intended test endpoint.

This fix checks whether the provided --xds-server-uri already contains the target region. If it does (as is the case with staging sandbox URIs), it applies that custom URI directly to the regional authority entry (traffic-director.<region>.xds.googleapis.com). Otherwise, it falls back to generating the standard production regional endpoint, ensuring staging tests route to the correct control plane while preserving existing testing and production behavior.